### PR TITLE
Add basic app structure with submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+
+
+# personal files
+.vscode/
+personal/
+
+# compiled binary
+sda-cli

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+SDA-CLI
+=======
+
+This is the Secure Data Archive (SDA) Command Line Interface (sda-cli). This
+tool was created to unify and simplify the tools needed to perform the most
+common user actions in the SDA.
+
+This tool can be used to encrypt and upload data when submitting to the archive,
+and to download and decrypt with retrieving data from the archive.
+
+To get help on the usage of the tool, please use the `./sda-cli help` command.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SDA-CLI
 =======
 
-This is the Secure Data Archive (SDA) Command Line Interface (sda-cli). This
+This is the Sensitive Data Archive (SDA) Command Line Interface (sda-cli). This
 tool was created to unify and simplify the tools needed to perform the most
 common user actions in the SDA.
 

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -1,0 +1,40 @@
+package decrypt
+
+import (
+	"flag"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Help text and command line flags.
+
+var Usage = `
+USAGE: %s decrypt -key <private-key-file> [file(s)]
+
+Decrypt: Encrypts files from the Secure Data Archive (SDA) with the provided
+         private key.
+`
+var ArgHelp = `
+  [file(s)]
+        all flagless arguments will be used as filenames for decryption.`
+
+var Args = flag.NewFlagSet("decrypt", flag.ExitOnError)
+
+var privateKey = Args.String("key", "",
+	"Private key to use for decrypting files.")
+
+// Main decryption function
+func Decrypt(args []string) {
+	Args.Parse(os.Args[1:])
+
+	// Args() returns the non-flag arguments, which we assume are filenames.
+	files := Args.Args()
+
+	// Check that we have a private key to decrypt with
+	if *privateKey == "" {
+		log.Fatal("A private key is required to decrypt data")
+	}
+
+	log.Infof("Encrypting files %s with key %s", files, *privateKey)
+}

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -12,7 +12,7 @@ import (
 var Usage = `
 USAGE: %s decrypt -key <private-key-file> [file(s)]
 
-Decrypt: Encrypts files from the Secure Data Archive (SDA) with the provided
+Decrypt: Encrypts files from the Sensitive Data Archive (SDA) with the provided
          private key.
 `
 var ArgHelp = `

--- a/download/download.go
+++ b/download/download.go
@@ -12,7 +12,7 @@ import (
 var Usage = `
 USAGE: %s download [url(s)]
 
-Download: Downloads files from the Secure Data Archive (SDA). If a directory is
+Download: Downloads files from the Sensitive Data Archive (SDA). If a directory is
           provided (ending with "/"), then the tool will attempt to first
           download the urls_list.txt file, and then download all files in this
           list. If file urls are given, they will be downloaded as-is.

--- a/download/download.go
+++ b/download/download.go
@@ -1,0 +1,36 @@
+package download
+
+import (
+	"flag"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Help text and command line flags.
+
+var Usage = `
+USAGE: %s download [url(s)]
+
+Download: Downloads files from the Secure Data Archive (SDA). If a directory is
+          provided (ending with "/"), then the tool will attempt to first
+          download the urls_list.txt file, and then download all files in this
+          list. If file urls are given, they will be downloaded as-is.
+`
+var ArgHelp = `
+  [urls]
+        all flagless arguments will be used as download urls.`
+
+var Args = flag.NewFlagSet("download", flag.ExitOnError)
+
+// Main download function
+func Download(args []string) {
+	// Parse flags. There are no flags at the moment, but in case some are added
+	// we check for them.
+	Args.Parse(os.Args[1:])
+
+	// Args() returns the non-flag arguments, which we assume are filenames.
+	urls := Args.Args()
+
+	log.Infof("Downloading urls %s", urls)
+}

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -1,0 +1,40 @@
+package encrypt
+
+import (
+	"flag"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Help text and command line flags.
+
+var Usage = `
+USAGE: %s encrypt [file(s)]
+
+Encrypt: Encrypts files according to the crypt4gh standard used in the Secure
+         Data Archive (SDA). Each given file will be encrypted and written to
+         <filename>.c4gh. Both encrypted and decrypted checksums will be
+         calculated and written to:
+          - checksum_decrypted.md5
+          - checksum_encrypted.md5
+          - checksum_decrypted.sha256
+          - checksum_encrypted.sha256
+`
+var ArgHelp = `
+  [files]
+        all flagless arguments will be used as filenames for encryption.`
+
+var Args = flag.NewFlagSet("encrypt", flag.ExitOnError)
+
+// Main encryption function
+func Encrypt(args []string) {
+	// Parse flags. There are no flags at the moment, but in case some are added
+	// we check for them.
+	Args.Parse(os.Args[1:])
+
+	// Args() returns the non-flag arguments, which we assume are filenames.
+	files := Args.Args()
+
+	log.Infof("Encrypting files: %s", files)
+}

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -12,7 +12,7 @@ import (
 var Usage = `
 USAGE: %s encrypt [file(s)]
 
-Encrypt: Encrypts files according to the crypt4gh standard used in the Secure
+Encrypt: Encrypts files according to the crypt4gh standard used in the Sensitive
          Data Archive (SDA). Each given file will be encrypted and written to
          <filename>.c4gh. Both encrypted and decrypted checksums will be
          calculated and written to:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/NBISweden/sda-cli
+
+go 1.17
+
+require github.com/sirupsen/logrus v1.8.1
+
+require golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/NBISweden/sda-cli/decrypt"
+	"github.com/NBISweden/sda-cli/download"
+	"github.com/NBISweden/sda-cli/encrypt"
+	"github.com/NBISweden/sda-cli/upload"
+	log "github.com/sirupsen/logrus"
+)
+
+var Usage = `USAGE: %s <command> [command-args]
+
+This is a helper tool that can help with common tasks when interacting with the
+Secure Data Archive (SDA).
+`
+
+//  Map of the sub-commands, and their arguments and usage text strings
+type commandInfo struct {
+	args    *flag.FlagSet
+	usage   string
+	argHelp string
+}
+
+var Commands = map[string]commandInfo{
+	"encrypt":  {encrypt.Args, encrypt.Usage, encrypt.ArgHelp},
+	"decrypt":  {decrypt.Args, decrypt.Usage, decrypt.ArgHelp},
+	"download": {download.Args, download.Usage, download.ArgHelp},
+	"upload":   {upload.Args, upload.Usage, upload.ArgHelp},
+}
+
+// Main does argument parsing, then delegates to one of the sub modules
+func main() {
+
+	command, args := ParseArgs()
+
+	switch command {
+	case "encrypt":
+		encrypt.Encrypt(args)
+	case "decrypt":
+		decrypt.Decrypt(args)
+	case "download":
+		download.Download(args)
+	case "upload":
+		upload.Upload(args)
+	default:
+		log.Fatal("Unknown command:", command)
+	}
+}
+
+// Parses the command line arguments into a command, and keep the rest of the
+// arguments for the subcommand
+func ParseArgs() (string, []string) {
+
+	// Print usage if no arguments are provided
+	if len(os.Args) < 2 {
+		Help("help")
+	}
+
+	// Extract `command` from arg 1, then remove it from the flag list.
+	command := os.Args[1]
+	os.Args = append(os.Args[:1], os.Args[2:]...)
+
+	// If `command` is help-like, we print the help text and exit
+	switch command {
+	case "-h", "help", "-help", "--help":
+		var subcommand string
+		if len(os.Args) > 1 {
+			subcommand = os.Args[1]
+		} else {
+			subcommand = "help"
+		}
+		Help(subcommand)
+	}
+
+	return command, os.Args
+}
+
+// Prints the main usage string, and the global help or command help depending
+// on the `command` arg.
+func Help(command string) {
+
+	info, is_legal := Commands[command]
+	if is_legal {
+		// print subcommand help
+		fmt.Fprintf(os.Stderr, info.usage, os.Args[0])
+		fmt.Fprintln(os.Stderr, "Command line arguments:")
+		info.args.PrintDefaults()
+		fmt.Fprintln(os.Stderr, info.argHelp)
+	} else {
+		if command != "help" {
+			fmt.Fprintf(os.Stderr, "Unknown command: %s\n", command)
+		}
+		// print main help
+		fmt.Fprintf(os.Stderr, Usage, os.Args[0])
+		fmt.Fprintln(os.Stderr, "The tool can help with these actions:")
+		for _, info := range Commands {
+			fmt.Fprintf(os.Stderr, "%s\n", info.usage)
+		}
+		fmt.Fprintf(os.Stderr,
+			"Use '%s <command> help' to get help with subcommand flags.\n",
+			os.Args[0])
+	}
+
+	os.Exit(1)
+}

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 var Usage = `USAGE: %s <command> [command-args]
 
 This is a helper tool that can help with common tasks when interacting with the
-Secure Data Archive (SDA).
+Sensitive Data Archive (SDA).
 `
 
 //  Map of the sub-commands, and their arguments and usage text strings

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -1,0 +1,38 @@
+package upload
+
+import (
+	"flag"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Help text and command line flags.
+
+var Usage = `
+USAGE: %s upload -config <s3config-file> [file(s)]
+
+Upload: Uploads files to the Secure Data Archive (SDA). All files to upload are
+        required to be encrypted and have the .c4gh file extension.
+`
+var ArgHelp = `
+  [file(s)]
+        all flagless arguments will be used as filenames to upload.`
+
+var Args = flag.NewFlagSet("upload", flag.ExitOnError)
+
+var config = Args.String("config", "", "S3 config file to use for uploading.")
+
+// Main upload function
+func Upload(args []string) {
+	Args.Parse(os.Args[1:])
+
+	// Args() returns the non-flag arguments, which we assume are filenames.
+	files := Args.Args()
+
+	// Check that we have a private key to decrypt with
+	if *config == "" {
+		log.Fatal("An s3config is required to upload data")
+	}
+	log.Infof("Uploading %s with config %s", files, *config)
+}

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -12,8 +12,8 @@ import (
 var Usage = `
 USAGE: %s upload -config <s3config-file> [file(s)]
 
-Upload: Uploads files to the Secure Data Archive (SDA). All files to upload are
-        required to be encrypted and have the .c4gh file extension.
+Upload: Uploads files to the Sensitive Data Archive (SDA). All files to upload
+		are required to be encrypted and have the .c4gh file extension.
 `
 var ArgHelp = `
   [file(s)]


### PR DESCRIPTION
I was trying to make the structure simple to work with, so I used main only for help and argument parsing, then moved the "work" (currently just placeholders) into separate modules.

About command line args. I decided to keep things minimal, so there are very few args. This helps in making things simpler and also makes it very hard to do anything wrong.

Took me some time to get into golang mode again - so please comment if something's ugly or un-go-like :) 