### PR TITLE
Removed older go version from workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.15, 1.16, 1.17]
+        go-version: [1.16, 1.17]
     steps:
 
       - name: Set up Go ${{ matrix.go-version }}


### PR DESCRIPTION
Removed go 1.15 from `tests.yaml` for consistency between workflow files