### PR TITLE
Enhancement/continue file encryption after checks

### DIFF
--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -195,12 +195,12 @@ func checkFiles(files []helpers.EncryptionFileSet) error {
 	for _, file := range files {
 		// check that the input file exists and is readable
 		if !helpers.FileIsReadable(file.Unencrypted) {
-			return fmt.Errorf("Cannot read input file %s", file.Unencrypted)
+			return fmt.Errorf("cannot read input file %s", file.Unencrypted)
 		}
 
 		// check that the output file doesn't exist
 		if helpers.FileExists(file.Encrypted) {
-			return fmt.Errorf("Outfile %s already exists", file.Encrypted)
+			return fmt.Errorf("outfile %s already exists", file.Encrypted)
 		}
 
 		// Check if the input file is already encrypted
@@ -218,10 +218,10 @@ func checkFiles(files []helpers.EncryptionFileSet) error {
 		magicWord := make([]byte, 8)
 		_, err = unEncryptedFile.Read(magicWord)
 		if err != nil {
-			return fmt.Errorf("Error reading input file %s, reason: %v", file.Unencrypted, err)
+			return fmt.Errorf("error reading input file %s, reason: %v", file.Unencrypted, err)
 		}
 		if string(magicWord) == "crypt4gh" {
-			return fmt.Errorf("Input file %s is already encrypted(.c4gh) - make sure the right pk was used", file.Unencrypted)
+			return fmt.Errorf("input file %s is already encrypted(.c4gh) - make sure the right pk was used", file.Unencrypted)
 		}
 	}
 

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -24,7 +24,7 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help encrypt` command
 var Usage = `
-USAGE: %s encrypt -key <public-key-file> (-outdir <dir>) [file(s)]
+USAGE: %s encrypt -key <public-key-file> (-outdir <dir>) (-continue=true) [file(s)]
 
 Encrypt: Encrypts files according to the crypt4gh standard used in the Sensitive
          Data Archive (SDA). Each given file will be encrypted and written to
@@ -49,6 +49,8 @@ var Args = flag.NewFlagSet("encrypt", flag.ExitOnError)
 var publicKeyFile = Args.String("key", "",
 	"Public key to use for encrypting files.")
 var outDir = Args.String("outdir", "", "Output directory for encrypted files")
+
+var continueEncrypt = Args.Bool("continue", false, "Do not exit on file errors but skip and continue.")
 
 // Encrypt takes a set of arguments, parses them, and attempts to encrypt the
 // given data files with the given public key file
@@ -94,6 +96,9 @@ func Encrypt(args []string) error {
 		// Skip files that do not pass the checks and print all error logs at the end
 		if err = checkFiles(eachFile); err != nil {
 			defer log.Errorf("Skipping input file %s. Reason: %s.", filename, err)
+			if !*continueEncrypt {
+				return fmt.Errorf("aborting")
+			}
 			skippedFiles++
 
 			continue

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -83,6 +83,7 @@ func Encrypt(args []string) error {
 		// Skip files that do not pass the checks
 		if err = checkFiles(eachFile); err != nil {
 			log.Errorf("Skipping input file %s. Reason: %s.", filename, err)
+
 			continue
 		}
 
@@ -91,7 +92,7 @@ func Encrypt(args []string) error {
 
 	// exit if files slice is empty
 	if len(files) == 0 {
-		return fmt.Errorf("No input files or all were skipped.")
+		return fmt.Errorf("no input files or all were skipped")
 	}
 
 	log.Infof("Ready to encrypt %d files", len(files))

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -209,12 +209,12 @@ func checkFiles(files []helpers.EncryptionFileSet) error {
 		}()
 
 		// Extracting the first 8 bytes of the header - crypt4gh
-		byteSlice := make([]byte, 8)
-		magicWord, err := unEncryptedFile.Read(byteSlice)
+		magicWord := make([]byte, 8)
+		_, err = unEncryptedFile.Read(magicWord)
 		if err != nil {
 			return fmt.Errorf("Error reading input file %s, reason: %v", file.Unencrypted, err)
 		}
-		if string(byteSlice[0:magicWord]) == "crypt4gh" {
+		if string(magicWord) == "crypt4gh" {
 			return fmt.Errorf("Input file %s is already encrypted(.c4gh) - make sure the right pk was used", file.Unencrypted)
 		}
 	}

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -182,19 +182,19 @@ func Encrypt(args []string) error {
 	return nil
 }
 
-// Checks that all the input files exists, and are readable, and that the
-// output files do not exist
+// Checks that all the input files exist, are readable and not already encrypted,
+// and that the output files do not exist
 func checkFiles(files []helpers.EncryptionFileSet) error {
 
 	for _, file := range files {
 		// check that the input file exists and is readable
 		if !helpers.FileIsReadable(file.Unencrypted) {
-			return fmt.Errorf("cannot read input file %s", file.Unencrypted)
+			return fmt.Errorf("Cannot read input file %s", file.Unencrypted)
 		}
 
 		// check that the output file doesn't exist
 		if helpers.FileExists(file.Encrypted) {
-			return fmt.Errorf("outfile %s already exists", file.Encrypted)
+			return fmt.Errorf("Outfile %s already exists", file.Encrypted)
 		}
 
 		// Check if the input file is already encrypted
@@ -212,10 +212,10 @@ func checkFiles(files []helpers.EncryptionFileSet) error {
 		byteSlice := make([]byte, 8)
 		magicWord, err := unEncryptedFile.Read(byteSlice)
 		if err != nil {
-			return err
+			return fmt.Errorf("Error reading input file %s, reason: %v", file.Unencrypted, err)
 		}
 		if string(byteSlice[0:magicWord]) == "crypt4gh" {
-			return fmt.Errorf("Input file %s is already encrypted(.c4gh)", file.Unencrypted)
+			return fmt.Errorf("Input file %s is already encrypted(.c4gh) - make sure the right pk was used", file.Unencrypted)
 		}
 	}
 

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -221,7 +221,7 @@ func checkFiles(files []helpers.EncryptionFileSet) error {
 			return fmt.Errorf("error reading input file %s, reason: %v", file.Unencrypted, err)
 		}
 		if string(magicWord) == "crypt4gh" {
-			return fmt.Errorf("input file %s is already encrypted(.c4gh) - make sure the right pk was used", file.Unencrypted)
+			return fmt.Errorf("input file %s is already encrypted(.c4gh)", file.Unencrypted)
 		}
 	}
 

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -89,6 +89,11 @@ func Encrypt(args []string) error {
 		files = append(files, eachFile[0])
 	}
 
+	// exit if files slice is empty
+	if len(files) == 0 {
+		return fmt.Errorf("No input files or all were skipped.")
+	}
+
 	log.Infof("Ready to encrypt %d files", len(files))
 
 	// Read the public key to be used for encryption. The private key

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -68,6 +68,7 @@ func Encrypt(args []string) error {
 	// All filenames that pass the checks are read into a struct together with their output filenames
 	files := []helpers.EncryptionFileSet{}
 
+	log.Info("Checking files")
 	for _, filename := range Args.Args() {
 
 		// Set directory for the output file
@@ -87,6 +88,8 @@ func Encrypt(args []string) error {
 
 		files = append(files, eachFile[0])
 	}
+
+	log.Infof("Ready to encrypt %d files", len(files))
 
 	// Read the public key to be used for encryption. The private key
 	// matching this public key will be able to decrypt the file.
@@ -182,7 +185,7 @@ func Encrypt(args []string) error {
 // Checks that all the input files exists, and are readable, and that the
 // output files do not exist
 func checkFiles(files []helpers.EncryptionFileSet) error {
-	log.Info("Checking files")
+
 	for _, file := range files {
 		// check that the input file exists and is readable
 		if !helpers.FileIsReadable(file.Unencrypted) {

--- a/encrypt/encrypt_test.go
+++ b/encrypt/encrypt_test.go
@@ -105,17 +105,17 @@ func (suite *EncryptTests) TestcheckFiles() {
 	// unencrypted is readable, but encrypted exists
 	testHasEncrypted := helpers.EncryptionFileSet{Unencrypted: suite.fileOk.Name(), Encrypted: suite.fileOk.Name()}
 	err = checkFiles([]helpers.EncryptionFileSet{testHasEncrypted})
-	assert.EqualError(suite.T(), err, fmt.Sprintf("outfile %s already exists", suite.fileOk.Name()))
+	assert.EqualError(suite.T(), err, fmt.Sprintf("Outfile %s already exists", suite.fileOk.Name()))
 
 	// unencrypted isn't readable
 	testNoUnencrypted := helpers.EncryptionFileSet{Unencrypted: "does-not-exist", Encrypted: suite.fileOk.Name()}
 	err = checkFiles([]helpers.EncryptionFileSet{testNoUnencrypted})
-	assert.EqualError(suite.T(), err, "cannot read input file does-not-exist")
+	assert.EqualError(suite.T(), err, "Cannot read input file does-not-exist")
 
 	// Encrypted file is given as input
 	verifyUnencrypted := helpers.EncryptionFileSet{Unencrypted: suite.encryptedFile.Name(), Encrypted: "does-not-exist"}
 	err = checkFiles([]helpers.EncryptionFileSet{verifyUnencrypted})
-	assert.EqualError(suite.T(), err, fmt.Sprintf("Input file %s is already encrypted(.c4gh)", suite.encryptedFile.Name()))
+	assert.EqualError(suite.T(), err, fmt.Sprintf("Input file %s is already encrypted(.c4gh) - make sure the right pk was used", suite.encryptedFile.Name()))
 
 }
 

--- a/encrypt/encrypt_test.go
+++ b/encrypt/encrypt_test.go
@@ -105,17 +105,17 @@ func (suite *EncryptTests) TestcheckFiles() {
 	// unencrypted is readable, but encrypted exists
 	testHasEncrypted := helpers.EncryptionFileSet{Unencrypted: suite.fileOk.Name(), Encrypted: suite.fileOk.Name()}
 	err = checkFiles([]helpers.EncryptionFileSet{testHasEncrypted})
-	assert.EqualError(suite.T(), err, fmt.Sprintf("Outfile %s already exists", suite.fileOk.Name()))
+	assert.EqualError(suite.T(), err, fmt.Sprintf("outfile %s already exists", suite.fileOk.Name()))
 
 	// unencrypted isn't readable
 	testNoUnencrypted := helpers.EncryptionFileSet{Unencrypted: "does-not-exist", Encrypted: suite.fileOk.Name()}
 	err = checkFiles([]helpers.EncryptionFileSet{testNoUnencrypted})
-	assert.EqualError(suite.T(), err, "Cannot read input file does-not-exist")
+	assert.EqualError(suite.T(), err, "cannot read input file does-not-exist")
 
 	// Encrypted file is given as input
 	verifyUnencrypted := helpers.EncryptionFileSet{Unencrypted: suite.encryptedFile.Name(), Encrypted: "does-not-exist"}
 	err = checkFiles([]helpers.EncryptionFileSet{verifyUnencrypted})
-	assert.EqualError(suite.T(), err, fmt.Sprintf("Input file %s is already encrypted(.c4gh) - make sure the right pk was used", suite.encryptedFile.Name()))
+	assert.EqualError(suite.T(), err, fmt.Sprintf("input file %s is already encrypted(.c4gh) - make sure the right pk was used", suite.encryptedFile.Name()))
 
 }
 

--- a/encrypt/encrypt_test.go
+++ b/encrypt/encrypt_test.go
@@ -115,7 +115,7 @@ func (suite *EncryptTests) TestcheckFiles() {
 	// Encrypted file is given as input
 	verifyUnencrypted := helpers.EncryptionFileSet{Unencrypted: suite.encryptedFile.Name(), Encrypted: "does-not-exist"}
 	err = checkFiles([]helpers.EncryptionFileSet{verifyUnencrypted})
-	assert.EqualError(suite.T(), err, fmt.Sprintf("input file %s is already encrypted(.c4gh) - make sure the right pk was used", suite.encryptedFile.Name()))
+	assert.EqualError(suite.T(), err, fmt.Sprintf("input file %s is already encrypted(.c4gh)", suite.encryptedFile.Name()))
 
 }
 


### PR DESCRIPTION
This PR adds the boolean flag `-continue` to encrypt. If `-continue=true`, encrypt will process all input files that pass the checks but ignore those that do not, instead of exiting prematurely. Info on the files skipped is returned to the user in the output logs.

Closes #11