### PR TITLE
Feature/recursive folder upload

### DIFF
--- a/.github/integration/tests/tests.sh
+++ b/.github/integration/tests/tests.sh
@@ -45,11 +45,9 @@ fi
 files="data_file.c4gh"
 check_encypted_file $files
 
-
 # Upload a specific file and check it
 ./sda-cli upload -config sda-s3proxy/dev_utils/s3cmd.conf data_file.c4gh
 check_uploaded_file test/dummy/data_file.c4gh data_file.c4gh
-
 
 # Create and encrypt multiple files in a folder
 dd if=/dev/random of=data_file1 count=1 bs=$(( 1024*1024 ))
@@ -67,6 +65,19 @@ do
     check_uploaded_file test/dummy/$k $k
 done
 
+# Create folder with subfolder structure and add some encrypted files
+mkdir data_files_enc/dir1 data_files_enc/dir1/dir2
+cp data_files_enc/data_file.c4gh data_files_enc/dir1/data_file.c4gh
+cp data_files_enc/data_file.c4gh data_files_enc/dir1/dir2/data_file.c4gh
+cp data_files_enc/data_file.c4gh data_files_enc/dir1/dir2/data_file2.c4gh
+
+# Upload folder recursively and check uploaded files
+./sda-cli upload -config sda-s3proxy/dev_utils/s3cmd.conf -dir data_files_enc/dir1
+
+for k in data_files_enc/dir1/data_file.c4gh data_files_enc/dir1/dir2/data_file.c4gh data_files_enc/dir1/dir2/data_file2.c4gh
+do
+    check_uploaded_file test/dummy/$k $k
+done
 
 # Dataset size using a local urls_list.txt
 echo "http://localhost:9000/download/A352764B-2KB4-4738-B6B5-BA55D25FB469/data_file.c4gh" > urls_list.txt
@@ -97,10 +108,10 @@ else
 fi
 
 # Remove files used for encrypt and upload
-rm -r data_files_enc 
+rm -r data_files_enc
 rm -r downloads
 rm sda_key* checksum_* urls_list.txt data_file*
- 
+
 
 # Dataset size using a url urls_list.txt
 output=$(./sda-cli datasetsize http://localhost:9000/download/A352764B-2KB4-4738-B6B5-BA55D25FB469/urls_list.txt | grep -q "Total dataset size: 1.00MB")

--- a/.github/workflows/golint.yaml
+++ b/.github/workflows/golint.yaml
@@ -11,7 +11,7 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
-        
+
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,15 +8,15 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-      
+
       - name: Set up Python
         uses: actions/setup-python@v3
 
       - name: Build go code
         run: go build
-      
+
       - name: Setup environment
         run: bash -x .github/integration/setup/setup.sh
-      
+
       - name: Run tests
         run: bash -x .github/integration/tests/tests.sh

--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ where `<configuration_file>` the file downloaded in the previous step and `<encr
 ```
 Note that the files will be uploaded creating the same folder structure as the local one. For example, if the `<encrypted_file_to_upload>` is located at `<folder_1>/<folder_2>/<encrypted_file_to_upload>`, then the same folder structure will be created in the archive.
 
+### Upload folder
+
+It is also possible to use the `sda-cli` tool to upload an entire directory recursively, i.e. including all contained files and folders while keeping the original folder structure. This can be done by using the `-dir` flag, e.g. running:
+```bash
+./sda-cli upload -config <configuration_file> -dir <folder_to_upload>
+```
+will upload `<folder_to_upload>` with the same folder and file structure as the local one to the archive. Note that it is not possible to specify both an entire folder and separate files for upload with the same command. When using folder upload, any argument after `<folder_to_upload>` in the above command will be skipped and has therefore no effect.
+
 ## Get dataset size
 
 Before downloading a dataset or a specific file, the `sda-cli` tool allows for requesting the size of each file, as well as the whole dataset. In order to use this functionality, the tool expects as an argument a file containing the location of the files in the dataset. The argument can be one of the following:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,13 @@ It is also possible to use the `sda-cli` tool to upload an entire directory recu
 ```bash
 ./sda-cli upload -config <configuration_file> -dir <folder_to_upload>
 ```
-will upload `<folder_to_upload>` with the same folder and file structure as the local one to the archive. Note that it is not possible to specify both an entire folder and separate files for upload with the same command. When using folder upload, any argument after `<folder_to_upload>` in the above command will be skipped and has therefore no effect.
+will upload `<folder_to_upload>` with the same folder and file structure as the local one to the archive. It is not possible to specify both an entire folder and separate files for upload with the same command. When using folder upload, any argument after `<folder_to_upload>` in the above command will be skipped and has therefore no effect.
+
+**Note**: the argument of `-dir` can be either a directory name, i.e. `test_folder` or a directory path, i.e. `some_data/test_folder`. In the latter case, the following command:
+```bash
+./sda-cli upload -config <configuration_file> -dir some_data/test_folder
+```
+will create the folder structure `some_data/test_folder` when uploading.
 
 ## Get dataset size
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/NBISweden/sda-cli
 go 1.17
 
 require (
-	github.com/aws/aws-sdk-go v1.44.14
+	github.com/aws/aws-sdk-go v1.44.17
 	github.com/elixir-oslo/crypt4gh v1.5.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ filippo.io/edwards25519 v1.0.0-rc.1 h1:m0VOOB23frXZvAOK44usCgLWvtsxIoMCTBGJZlpmG
 filippo.io/edwards25519 v1.0.0-rc.1/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
 github.com/aws/aws-sdk-go v1.44.14 h1:qd7/muV1rElsbvkK9D1nHUzBoDlEw2etfeo4IE82eSQ=
 github.com/aws/aws-sdk-go v1.44.14/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.44.17 h1:of8MirZuVDat3BJgRbSwDO/GM/cgXh5Znf2tyEAv/vE=
+github.com/aws/aws-sdk-go v1.44.17/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -134,6 +134,10 @@ func checkTokenExpiration(accessToken string) (bool, error) {
 // Function uploadFiles uploads the files in the input list to the s3 bucket
 func uploadFiles(files []string, config *Config) error {
 
+	if len(files) == 0 {
+		return errors.New("no files to upload")
+	}
+
 	// The session the S3 Uploader will use
 	sess := session.Must(session.NewSession(&aws.Config{
 		// The region for the backend is always the specified one

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -180,9 +180,16 @@ func uploadFiles(files []string, config *Config) error {
 // Function getFilePaths retrieves all relative file paths within a folder recursively
 func getFilePaths(dirPath string) ([]string, error) {
 	var files []string
-
+	// Check that input is a directory
+	fileInfo, err := os.Stat(dirPath)
+	if err != nil {
+		return nil, err
+	}
+	if !fileInfo.IsDir() {
+		return nil, errors.New(dirPath + " is not a directory")
+	}
 	// List all directory contents recursively including relative paths
-	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			fmt.Println(err)
 

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -180,12 +180,6 @@ func Upload(args []string) error {
 		return fmt.Errorf("failed parsing arguments, reason: %v", err)
 	}
 
-	// Args() returns the non-flag arguments, which we assume are filenames.
-	files := Args.Args()
-	if len(files) == 0 {
-		return errors.New("no files to upload")
-	}
-
 	// Check that we have a private key to decrypt with
 	if *configPath == "" {
 		return errors.New("failed to find an s3 configuration file for uploading data")
@@ -204,6 +198,12 @@ func Upload(args []string) error {
 	if expiring {
 		fmt.Println("The provided token expires in less than 24 hours")
 		fmt.Println("Consider renewing the token.")
+	}
+
+	// Args() returns the non-flag arguments, which we assume are filenames.
+	files := Args.Args()
+	if len(files) == 0 {
+		return errors.New("no files to upload")
 	}
 
 	// Upload files

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -25,7 +25,7 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help download` command
 var Usage = `
-USAGE: %s upload -config <s3config-file> [file(s)]
+USAGE: %s upload -config <s3config-file> (-dir <dir>) [file(s)]
 
 Upload: Uploads files to the Sensitive Data Archive (SDA). All files to upload
         are required to be encrypted and have the .c4gh file extension.
@@ -35,7 +35,7 @@ Upload: Uploads files to the Sensitive Data Archive (SDA). All files to upload
 // the module help
 var ArgHelp = `
   [file(s)]
-        all flagless arguments will be used as filenames to upload.`
+        if '-dir <dir>' is not provided, all flagless arguments will be used as filenames to upload.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -152,9 +152,17 @@ func (suite *TestSuite) TestSampleNoFiles() {
 		log.Printf("failed to write temp config file, %v", err)
 	}
 
+	// Test Upload function
 	os.Args = []string{"upload", "-config", configPath.Name()}
 
 	err = Upload(os.Args)
+	assert.EqualError(suite.T(), err, "no files to upload")
+
+	// Test uploadFiles function
+	config, _ := loadConfigFile(configPath.Name())
+	var files []string
+
+	err = uploadFiles(files, config)
 	assert.EqualError(suite.T(), err, "no files to upload")
 }
 

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -188,3 +188,31 @@ func (suite *TestSuite) TestTokenExpiration() {
 	assert.NoError(suite.T(), err)
 	assert.False(suite.T(), expiring)
 }
+
+func (suite *TestSuite) TestgetFilePaths() {
+
+	// Create temp dir with file
+	dir, err := ioutil.TempDir(os.TempDir(), "test")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	testfile, err := ioutil.TempFile(dir, "testfile")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(testfile.Name())
+
+	// Input is a file
+	_, err = getFilePaths(testfile.Name())
+	assert.ErrorContains(suite.T(), err, "is not a directory")
+
+	// Input is a directory
+	_, err = getFilePaths(dir)
+	assert.Nil(suite.T(), err)
+
+	// Input is invalid
+	_, err = getFilePaths("nonexistent")
+	assert.ErrorContains(suite.T(), err, "no such file or directory")
+}

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -124,9 +124,37 @@ encrypt = False
 
 func (suite *TestSuite) TestSampleNoFiles() {
 
-	os.Args = []string{"upload", "-config", "upload/s3cmd.conf"}
+	var confFile = `
+	access_token = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxNzA3NDgzOTQ0IiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjoxNzA3NDgzOTQ0fQ.D7hrpd3ROXp53NnXa0PL9js2Oi1KqpKpkVMic1B23X84ksX9kbbtn4Ad4BkhO8Tm35a5hBu95CGgw5b06sd3LQ"
+	host_base = someHostBase
+	encoding = UTF-8
+	host_bucket = someHostBase
+	multipart_chunk_size_mb = 50
+	secret_key = someUser
+	access_key = someUser
+	use_https = True
+	check_ssl_certificate = False
+	check_ssl_hostname = False
+	socket_timeout = 30
+	human_readable_sizes = True
+	guess_mime_type = True
+	encrypt = False
+	`
+	configPath, err := ioutil.TempFile(os.TempDir(), "s3cmd.conf")
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	err := Upload(os.Args)
+	defer os.Remove(configPath.Name())
+
+	err = ioutil.WriteFile(configPath.Name(), []byte(confFile), 0600)
+	if err != nil {
+		log.Printf("failed to write temp config file, %v", err)
+	}
+
+	os.Args = []string{"upload", "-config", configPath.Name()}
+
+	err = Upload(os.Args)
 	assert.EqualError(suite.T(), err, "no files to upload")
 }
 

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -194,13 +194,13 @@ func (suite *TestSuite) TestgetFilePaths() {
 	// Create temp dir with file
 	dir, err := ioutil.TempDir(os.TempDir(), "test")
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	defer os.RemoveAll(dir)
 
 	testfile, err := ioutil.TempFile(dir, "testfile")
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	defer os.Remove(testfile.Name())
 


### PR DESCRIPTION
With this PR the user can give the flag `-dir` and a `<folder_name>` as input to `upload` and that folder will be uploaded recursively, preserving the local folder and file structure. Summary of changes:

- refactored the file upload logic into a function
- added another function to create a list with all paths of files inside a folder
- added new flag `-dir <upload_dir>`. Here I chose to use a flag and a folder name so that the user explicitly makes the choice for uploading a complete folder. 
- moved checks of valid conf and token before checks of file input since the former should be faster to fail
- updated test suite to reflect changes made
- updated readme with usage instructions

Closes #62.
Since uploading a complete folder increases the chance of uploading unencrypted files, it seems reasonable to implement #60 soon.

Converted to draft. Changes are needed to mimic the functionality of `cp` more closely.