### PR TITLE
Feature/encrypt and upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ where `<public_key>` the key downloaded in the previous step. The tool also allo
 ```
 This command comes with the `-continue` option, which will continue encrypting files, even if one of them fails. To enable this feature, the command should be executed with the `-continue=true` option.
 
+**Note**: The `encrypt` command will create four files containing hashes (both md5 and sha256) for the encrypted and unencrypted files, respectively.
+
 **Developers' Notes:** The tool is creating a key pair when encrypting the files. This key pair is temporary for security reasons.
 
 
@@ -94,6 +96,26 @@ As a side note the argument list may include wildcards, for example,
 ./sda-cli upload -config <configuration_file> -r <folder_to_upload>/. -targetDir <new_folder_name>
 ```
 will upload all contents of `<folder_to_upload>` to `<new_folder_name>` recursively, effectively renaming `<folder_to_upload>` upon upload to the archive.
+
+### Encrypt on upload
+
+It is possible to combine the encryption and upload steps into with the use of the flag `--encrypt-with-key` followed by the path of the crypt4gh public key to be used for encryption. In this case, the input list of file arguments can only contain *unencrypted* source files. For example the following,
+```bash
+./sda-cli upload -config <configuration_file> --encrypt-with-key <public_key> <unencrypted_file_to_upload>
+```
+will encrypt `<unencrypted_file_to_upload>` using `<public_key>` as public key and upload the created `<file_to_upload.c4gh>`  in the base folder of the user. 
+
+Encrypt on upload can be combined with any of the flags above. For example,
+```bash
+./sda-cli upload -config <configuration_file> --encrypt-with-key <public_key> -r <folder_to_upload_with_unencrypted_data> -targetDir <new_folder_name>
+```
+will first encrypt all files in `<folder_to_upload_with_unencrypted_data>` and then upload the folder recursively (selecting only the created `c4gh` files) under `<new_folder_name>`.
+
+**Notes**: The tool calls the `encrypt` module internally, therefore similar behavior to that command is expected, including the creation of hash files. In addition,
+
+- If the input includes encrypted files, the tool will exit without performing further tasks.
+- The encrypted files will be created next to their unencrypted counterparts.
+- The tool will not overwrite existing encrypted files. It will exit early if encrypted counterparts of the source files already exist with the same source path.
 
 ## Get dataset size
 

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/NBISweden/sda-cli/encrypt"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -25,7 +26,7 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help download` command
 var Usage = `
-USAGE: %s upload -config <s3config-file> (-r) [file(s)|folder(s)] (-targetDir <upload-directory>)
+USAGE: %s upload -config <s3config-file> (--encrypt-with-key <public-key-file>) (-r) [file(s)|folder(s)] (-targetDir <upload-directory>)
 
 Upload: Uploads files to the Sensitive Data Archive (SDA). All files to upload
         are required to be encrypted and have the .c4gh file extension.
@@ -46,6 +47,8 @@ var configPath = Args.String("config", "", "S3 config file to use for uploading.
 var dirUpload = Args.Bool("r", false, "Upload directories recursively.")
 
 var targetDir = Args.String("targetDir", "", "Upload files|folders into this directory. If flag is omitted, all data will be uploaded in the user's base directory.")
+
+var pubKeyPath = Args.String("encrypt-with-key", "", "Public key to use for encryption of files before upload. The argument list may include only unencrypted data if this flag is set.")
 
 // Config struct for storing the s3cmd file values
 type Config struct {
@@ -319,6 +322,23 @@ func Upload(args []string) error {
 			outFiles = append(outFiles, filepath.Base(filePath))
 		}
 	}
+
+	if *pubKeyPath != "" {
+		// Prepare input arg list for Encrypt function
+		encryptArgs := []string{args[0], "-key", *pubKeyPath}
+		encryptArgs = append(encryptArgs, files...)
+
+		if err = encrypt.Encrypt(encryptArgs); err != nil {
+			return err
+		}
+
+		// Modify slices so that we upload only the encrypted files
+		for k := 0; k < len(files); k++ {
+			files[k] += ".c4gh"
+			outFiles[k] += ".c4gh"
+		}
+	}
+
 	// Upload files
 	if err = uploadFiles(files, outFiles, *targetDir, config); err != nil {
 		return err

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -323,6 +323,11 @@ func Upload(args []string) error {
 		}
 	}
 
+	// If files list is empty fail here before calling Encrypt
+	if len(files) == 0 {
+		return errors.New("no files to upload")
+	}
+
 	if *pubKeyPath != "" {
 		// Prepare input arg list for Encrypt function
 		encryptArgs := []string{args[0], "-key", *pubKeyPath}

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -425,4 +425,18 @@ func (suite *TestSuite) TestFunctionality() {
 	newArgs = []string{"upload", "-config", configPath.Name(), "--encrypt-with-key", "somekey", testfile.Name()}
 	err = Upload(newArgs)
 	assert.EqualError(suite.T(), err, "aborting")
+
+	// Remove hash files created by Encrypt
+	if err := os.Remove("checksum_encrypted.md5"); err != nil {
+		log.Panic(err)
+	}
+	if err := os.Remove("checksum_unencrypted.md5"); err != nil {
+		log.Panic(err)
+	}
+	if err := os.Remove("checksum_encrypted.sha256"); err != nil {
+		log.Panic(err)
+	}
+	if err := os.Remove("checksum_unencrypted.sha256"); err != nil {
+		log.Panic(err)
+	}
 }

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/elixir-oslo/crypt4gh/keys"
 	"github.com/johannesboyne/gofakes3"
 	"github.com/johannesboyne/gofakes3/backend/s3mem"
 	log "github.com/sirupsen/logrus"
@@ -316,6 +317,10 @@ func (suite *TestSuite) TestFunctionality() {
 	if err != nil {
 		log.Panic(err)
 	}
+	err = ioutil.WriteFile(testfile.Name(), []byte("content"), 0600)
+	if err != nil {
+		log.Printf("failed to write temp config file, %v", err)
+	}
 	defer os.Remove(testfile.Name())
 
 	var str bytes.Buffer
@@ -359,4 +364,65 @@ func (suite *TestSuite) TestFunctionality() {
 		log.Panic(err.Error())
 	}
 	assert.Equal(suite.T(), aws.StringValue(result.Contents[0].Key), fmt.Sprintf("a/%s", filepath.Base(testfile.Name())))
+
+	// Test encrypt-with-key on upload.
+	// Tests specific to encrypt module are not repeated here.
+
+	// Generate a crypt4gh pub key
+	pubKeyData, _, err := keys.GenerateKeyPair()
+	if err != nil {
+		log.Panic("Couldn't generate key pair", err)
+	}
+
+	// Write the keys to temporary files
+	publicKey, err := ioutil.TempFile(dir, "pubkey-")
+	if err != nil {
+		log.Panic("Cannot create temporary public key file", err)
+	}
+
+	err = keys.WriteCrypt4GHX25519PublicKey(publicKey, pubKeyData)
+	if err != nil {
+		log.Panicf("failed to write temporary public key file, %v", err)
+	}
+
+	// Empty buffer logs
+	str.Reset()
+	newArgs := []string{"upload", "-config", configPath.Name(), "--encrypt-with-key", publicKey.Name(), testfile.Name(), "-targetDir", "someDir"}
+	err = Upload(newArgs)
+	assert.NoError(suite.T(), err)
+
+	// Check logs that encrypted file was uploaded
+	logMsg = fmt.Sprintf("%v", strings.TrimSuffix(str.String(), "\n"))
+	msg = fmt.Sprintf("file uploaded to %s/dummy/someDir/%s.c4gh", ts.URL, filepath.Base(testfile.Name()))
+	assert.Contains(suite.T(), logMsg, msg)
+
+	// Check that file showed up in the s3 bucket correctly
+	result, err = s3Client.ListObjects(&s3.ListObjectsInput{
+		Bucket: aws.String("dummy"),
+	})
+	if err != nil {
+		log.Panic(err.Error())
+	}
+	assert.Equal(suite.T(), aws.StringValue(result.Contents[1].Key), "someDir/"+filepath.Base(testfile.Name())+".c4gh")
+
+	// Check that the respective unencrypted file was not uploaded
+	msg = fmt.Sprintf("Uploading %s with", testfile.Name())
+	assert.NotContains(suite.T(), logMsg, msg)
+
+	// Check that trying to encrypt already encrypted files returns error and aborts
+	newArgs = []string{"upload", "-config", configPath.Name(), "--encrypt-with-key", publicKey.Name(), dir, "-r"}
+	err = Upload(newArgs)
+	assert.EqualError(suite.T(), err, "aborting")
+
+	// Check handling of passing source files as pub key
+	// (code checks first for errors related with file args)
+	newArgs = []string{"upload", "-config", configPath.Name(), "--encrypt-with-key", testfile.Name()}
+	err = Upload(newArgs)
+	assert.EqualError(suite.T(), err, "no files to upload")
+
+	// If both a bad key and already encrypted file args are given,
+	// file arg errors are captured first
+	newArgs = []string{"upload", "-config", configPath.Name(), "--encrypt-with-key", "somekey", testfile.Name()}
+	err = Upload(newArgs)
+	assert.EqualError(suite.T(), err, "aborting")
 }


### PR DESCRIPTION
This PR adds "encrypt and upload" functionality to the sda-cli's `upload` command. Specifically, the user can pass the flag `--encrypt-with-key` followed by the public key file and the source files will be first encrypted and then uploaded in one go. The code calls the `Encrypt` function internally so it inherits its behavior for the first step. If input source files include already encrypted files then the tool will exit before encryption and thus before upload.

Main additions:

- add new flag `--encrypt-with-key` and related functionality
- extend test suite of upload
- add integration tests
- update readme

Closes #60