### PR TITLE
Feature/multiple key encryption

### DIFF
--- a/.github/integration/setup/setup.sh
+++ b/.github/integration/setup/setup.sh
@@ -12,7 +12,14 @@ openssl rsa -in dummy.ega.nbis.se.pem -pubout -out keys/dummy.ega.nbis.se.pub
 output=$(bash sign_jwt.sh RS256 dummy.ega.nbis.se.pem)
 echo "access_token=$output" >> s3cmd.conf
 
-docker-compose up -d
+# check which compose syntax to use (useful for running locally)
+if ( command -v docker-compose >/dev/null 2>&1 )
+then
+    docker-compose up -d
+else
+    docker compose up -d
+fi
+
 RETRY_TIMES=0
 until docker ps -f name="s3" --format "{{.Status}}" | grep "healthy"
 do echo "waiting for s3 to become ready"

--- a/.github/integration/setup/setup.sh
+++ b/.github/integration/setup/setup.sh
@@ -12,8 +12,6 @@ openssl rsa -in dummy.ega.nbis.se.pem -pubout -out keys/dummy.ega.nbis.se.pub
 output=$(bash sign_jwt.sh RS256 dummy.ega.nbis.se.pem)
 echo "access_token=$output" >> s3cmd.conf
 
-sh make_certs.sh
-
 docker-compose up -d
 RETRY_TIMES=0
 until docker ps -f name="s3" --format "{{.Status}}" | grep "healthy"

--- a/.github/integration/tests/tests.sh
+++ b/.github/integration/tests/tests.sh
@@ -173,6 +173,40 @@ else
     exit 1
 fi
 
+# Test multiple pub key encryption
+
+# Create another key-pair
+if ( echo "" | ./sda-cli createKey sda_key2 ) ; then
+    echo "Created key pair for encryption"
+else
+    echo "Failed to create key pair for encryption"
+    exit 1
+fi
+# Create test file and encrypt
+cp data_file data_file_2keys
+./sda-cli encrypt -key sda_key.pub.pem -key sda_key2.pub.pem data_file_2keys
+check_encypted_file "data_file_2keys.c4gh"
+rm data_file_2keys
+# Decrypt file with first key
+./sda-cli decrypt -key sda_key.sec.pem data_file_2keys.c4gh
+if [ -f data_file_2keys ]; then
+    echo "Decrypted data file"
+else
+    echo "Failed to decrypt data file"
+    exit 1
+fi
+rm data_file_2keys
+# Decrypt file with second key
+./sda-cli decrypt -key sda_key2.sec.pem data_file_2keys.c4gh
+
+# decrypted_file_exists "data_file_2keys"
+if [ -f data_file_2keys ]; then
+    echo "Decrypted data file"
+else
+    echo "Failed to decrypt data file"
+    exit 1
+fi
+
 # Remove files used for encrypt and upload
 rm -r data_files_enc
 rm -r data_files_unenc

--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ where `<public_key>` the key downloaded in the previous step. The tool also allo
 ```
 This command comes with the `-continue` option, which will continue encrypting files, even if one of them fails. To enable this feature, the command should be executed with the `-continue=true` option.
 
+### Encrypt file(s) with multiple keys
+
+To encrypt files with more than one public keys, repeatedly use the `-key` flag, e.g.
+```bash
+./sda-cli encrypt -key <public_key1> -key <public_key2> <file_to_encrypt>
+```
+will encrypt a file using two keys so that it can be decrypted with either of the corresponding private keys. Encryption with more than two keys is possible, as well. Another option is to provide as argument to `-key` a file with concatenated public keys generated e.g. from a command like
+```bash
+cat <pub_key1> <pub_key2> > <concatenated_pub_keys>
+```
+Passing a combination of the above arguments is allowed, as well:
+```bash
+./sda-cli encrypt -key <concatenated_public_keys> -key <public_key3> <file_to_encrypt>
+```
+
 **Note**: The `encrypt` command will create four files containing hashes (both md5 and sha256) for the encrypted and unencrypted files, respectively.
 
 **Developers' Notes:** The tool is creating a key pair when encrypting the files. This key pair is temporary for security reasons.
@@ -103,7 +118,7 @@ It is possible to combine the encryption and upload steps into with the use of t
 ```bash
 ./sda-cli upload -config <configuration_file> --encrypt-with-key <public_key> <unencrypted_file_to_upload>
 ```
-will encrypt `<unencrypted_file_to_upload>` using `<public_key>` as public key and upload the created `<file_to_upload.c4gh>`  in the base folder of the user. 
+will encrypt `<unencrypted_file_to_upload>` using `<public_key>` as public key and upload the created `<file_to_upload.c4gh>`  in the base folder of the user.
 
 Encrypt on upload can be combined with any of the flags above. For example,
 ```bash
@@ -111,8 +126,9 @@ Encrypt on upload can be combined with any of the flags above. For example,
 ```
 will first encrypt all files in `<folder_to_upload_with_unencrypted_data>` and then upload the folder recursively (selecting only the created `c4gh` files) under `<new_folder_name>`.
 
-**Notes**: The tool calls the `encrypt` module internally, therefore similar behavior to that command is expected, including the creation of hash files. In addition,
+**Notes**: The tool calls the [encrypt](#Encrypt) module internally, therefore similar behavior to that command is expected, including the creation of hash files. In addition,
 
+- For encryption with [multiple public keys](#Encrypt-file(s)-with-multiple-keys), concatenate all public keys into one file and pass it as the argument to `encrypt-with-key`.
 - If the input includes encrypted files, the tool will exit without performing further tasks.
 - The encrypted files will be created next to their unencrypted counterparts.
 - The tool will not overwrite existing encrypted files. It will exit early if encrypted counterparts of the source files already exist with the same source path.

--- a/create_key/create_key.go
+++ b/create_key/create_key.go
@@ -18,7 +18,7 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help encrypt` command
 var Usage = `
-USAGE: %s createKey <name> (-outdir <dirname>)
+USAGE: %s createKey (-outdir <dirname>) <name>
 
 createKey: Creates a crypt4gh encryption key pair, and saves it to
            <name>.pub.pem, and <name>.sec.pem.

--- a/datasetsize/datasetsize.go
+++ b/datasetsize/datasetsize.go
@@ -20,7 +20,7 @@ import (
 var Usage = `
 USAGE: %s datasetsize [url(s) | file]
 
-Datasetsize: List files that can be downloaded from the Sensitive Data Archive (SDA).
+datasetsize: List files that can be downloaded from the Sensitive Data Archive (SDA).
 	  If a URL is provided (ending with "/" or the urls_list.txt file), then the tool 
 	  will attempt to first download the urls_list.txt file, and then return a list 
 	  of the files with their respective sizes.

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -22,7 +22,7 @@ import (
 var Usage = `
 USAGE: %s decrypt -key <private-key-file> [file(s)]
 
-Decrypt: Decrypts files from the Sensitive Data Archive (SDA) with the provided
+decrypt: Decrypts files from the Sensitive Data Archive (SDA) with the provided
          private key. If the private key is encrypted, the password can be
          supplied in the C4GH_PASSWORD environment variable, or at the interactive
          password prompt.

--- a/download/download.go
+++ b/download/download.go
@@ -21,11 +21,11 @@ import (
 var Usage = `
 USAGE: %s download (-outdir <dir>) [url(s) | file]
 
-Download: Downloads files from the Sensitive Data Archive (SDA). The files will
+download: Downloads files from the Sensitive Data Archive (SDA). The files will
 	  be downloaded in the current directory, if outdir is not defined.
-	  If a directory is provided (ending with "/"), then the tool will attempt 
-	  to first download the urls_list.txt file, and then download all files in 
-	  this list. If file urls are given, they files will be downloaded creating 
+	  If a directory is provided (ending with "/"), then the tool will attempt
+	  to first download the urls_list.txt file, and then download all files in
+	  this list. If file urls are given, they files will be downloaded creating
 	  the same folder structure locally.
 `
 

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -26,7 +26,7 @@ import (
 var Usage = `
 USAGE: %s encrypt -key <public-key-file> (-outdir <dir>) (-continue=true) [file(s)]
 
-Encrypt: Encrypts files according to the crypt4gh standard used in the Sensitive
+encrypt: Encrypts files according to the crypt4gh standard used in the Sensitive
          Data Archive (SDA). Each given file will be encrypted and written to
          <filename>.c4gh. Both encrypted and unencrypted checksums will be
          calculated and written to:

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -128,10 +128,7 @@ func Encrypt(args []string) error {
 	log.Infof("Ready to encrypt %d file(s)", len(files))
 
 	// Initialize a c4gh public key specs instance
-	c4ghKeySpecs := keySpecs{
-		rgx:    regexp.MustCompile(`-{5}BEGIN CRYPT4GH PUBLIC KEY-{5}\n.*\n-{5}END CRYPT4GH PUBLIC KEY-{5}`),
-		nbytes: 115,
-	}
+	c4ghKeySpecs := newKeySpecs()
 
 	// Read the public key(s) to be used for encryption. The matching private
 	// key will be able to decrypt the file.
@@ -503,6 +500,13 @@ func createPubKeyList(publicKeyFileList []string, c4ghKeySpecs keySpecs) ([][32]
 	}
 
 	return pubKeyList, nil
+}
+
+func newKeySpecs() keySpecs {
+	return keySpecs{
+		rgx:    regexp.MustCompile(`-{5}BEGIN CRYPT4GH PUBLIC KEY-{5}\n.*\n-{5}END CRYPT4GH PUBLIC KEY-{5}`),
+		nbytes: 115,
+	}
 }
 
 // struct to keep track of all the checksums for a given unencrypted input file.

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -126,14 +126,9 @@ func Encrypt(args []string) error {
 
 	// Read the public key(s) to be used for encryption. The matching private
 	// key will be able to decrypt the file.
-	pubKeyList := [][32]byte{}
-	for _, pubkey := range publicKeyFileList {
-		publicKey, err := readPublicKey(pubkey)
-		if err != nil {
-			return err
-		}
-		pubKeyList = append(pubKeyList, *publicKey)
-		fmt.Println(pubKeyList)
+	pubKeyList, err := createPubKeyList(publicKeyFileList)
+	if err != nil {
+		return err
 	}
 
 	// Generate a random private key to encrypt the data
@@ -397,9 +392,22 @@ func encrypt(filename, outFilename string, pubKeyList [][32]byte, privateKey [32
 	return nil
 }
 
-//
-// structs
-//
+// Takes a key file list and returns the parsed public key(s)
+// in a list ready to be used by crypt4gh package
+func createPubKeyList(publicKeyFileList []string) ([][32]byte, error) {
+	pubKeyList := [][32]byte{}
+
+	for _, pubkey := range publicKeyFileList {
+
+		publicKey, err := readPublicKey(pubkey)
+		if err != nil {
+			return nil, err
+		}
+		pubKeyList = append(pubKeyList, *publicKey)
+	}
+
+	return pubKeyList, nil
+}
 
 // struct to keep track of all the checksums for a given unencrypted input file.
 type hashSet struct {

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -57,6 +57,7 @@ var publicKeyFileList []string
 func init() {
 	Args.Func("key", "Public key file(s) to use for encryption. Use multiple times to encrypt\nwith more public keys. Key file(s) may contain many concatenated keys.", func(s string) error {
 		publicKeyFileList = append(publicKeyFileList, s)
+
 		return nil
 	})
 }

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -55,7 +55,7 @@ var continueEncrypt = Args.Bool("continue", false, "Do not exit on file errors b
 var publicKeyFileList []string
 
 func init() {
-	Args.Func("key", "Public key file(s) to use for encryption. \nUse multiple times to encrypt with multiple public keys", func(s string) error {
+	Args.Func("key", "Public key file(s) to use for encryption. Use multiple times to encrypt\nwith more public keys. Key file(s) may contain many concatenated keys.", func(s string) error {
 		publicKeyFileList = append(publicKeyFileList, s)
 		return nil
 	})

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -129,7 +129,7 @@ func Encrypt(args []string) error {
 
 	// Initialize a c4gh public key specs instance
 	c4ghKeySpecs := keySpecs{
-		rgx:    regexp.MustCompile(`-{5}[A-Z]*\s[4A-Z]*\s[A-Z]*\s[A-Z]*-{5}\n.*\n-{5}[A-Z]*\s[4A-Z]*\s[A-Z]*\s[A-Z]*-{5}`),
+		rgx:    regexp.MustCompile(`-{5}BEGIN CRYPT4GH PUBLIC KEY-{5}\n.*\n-{5}END CRYPT4GH PUBLIC KEY-{5}`),
 		nbytes: 115,
 	}
 

--- a/encrypt/encrypt_test.go
+++ b/encrypt/encrypt_test.go
@@ -120,7 +120,7 @@ func (suite *EncryptTests) TestcheckFiles() {
 }
 
 func (suite *EncryptTests) TestreadPublicKey() {
-	publicKey, err := readPublicKey(suite.publicKey.Name())
+	publicKey, err := readPublicKeyFile(suite.publicKey.Name())
 	assert.NoError(suite.T(), err)
 	suite.Equal(*publicKey, suite.pubKeyData)
 }

--- a/encrypt/encrypt_test.go
+++ b/encrypt/encrypt_test.go
@@ -145,3 +145,15 @@ func (suite *EncryptTests) TestcalculateHashes() {
 	suite.Equal(hashes.encryptedMd5, "9a0364b9e99bb480dd25e1f0284c8555")
 	suite.Equal(hashes.encryptedSha256, "ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73")
 }
+
+func (suite *EncryptTests) TestEncryptFunction() {
+	// pub key not given
+	os.Args = []string{"encrypt", suite.fileOk.Name()}
+	err := Encrypt(os.Args)
+	assert.EqualError(suite.T(), err, "public key not provided")
+
+	// no such pub key file
+	os.Args = []string{"encrypt", "-key", "somekey", suite.fileOk.Name()}
+	err = Encrypt(os.Args)
+	assert.EqualError(suite.T(), err, "open somekey: no such file or directory")
+}

--- a/encrypt/encrypt_test.go
+++ b/encrypt/encrypt_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -163,10 +162,7 @@ func (suite *EncryptTests) TestreadPublicKeyFile() {
 }
 
 func (suite *EncryptTests) TestreadMultiPublicKeyFile() {
-	specs := keySpecs{
-		rgx:    regexp.MustCompile(`-{5}[A-Z]*\s[4A-Z]*\s[A-Z]*\s[A-Z]*-{5}\n.*\n-{5}[A-Z]*\s[4A-Z]*\s[A-Z]*\s[A-Z]*-{5}`),
-		nbytes: 115,
-	}
+	specs := newKeySpecs()
 	publicKey, err := readMultiPublicKeyFile(suite.multiPublicKey.Name(), specs)
 	assert.NoError(suite.T(), err)
 	b := *publicKey
@@ -175,10 +171,7 @@ func (suite *EncryptTests) TestreadMultiPublicKeyFile() {
 }
 
 func (suite *EncryptTests) TestcheckKeyFile() {
-	specs := keySpecs{
-		rgx:    regexp.MustCompile(`-{5}[A-Z]*\s[4A-Z]*\s[A-Z]*\s[A-Z]*-{5}\n.*\n-{5}[A-Z]*\s[4A-Z]*\s[A-Z]*\s[A-Z]*-{5}`),
-		nbytes: 115,
-	}
+	specs := newKeySpecs()
 	// file that contains key(s) in valid format
 	size, err := checkKeyFile(suite.multiPublicKey.Name(), specs)
 	assert.NoError(suite.T(), err)

--- a/encrypt/encrypt_test.go
+++ b/encrypt/encrypt_test.go
@@ -80,7 +80,7 @@ func (suite *EncryptTests) SetupTest() {
 		log.Fatal("Cannot read from public key file", err)
 	}
 
-	err = os.WriteFile(suite.multiPublicKey.Name(), append(input, input...), 0644)
+	err = os.WriteFile(suite.multiPublicKey.Name(), append(input, input...), 0600)
 	if err != nil {
 		log.Fatal("cannot write to temporary multi-key file", err)
 	}
@@ -142,17 +142,17 @@ func (suite *EncryptTests) TestcheckFiles() {
 
 func (suite *EncryptTests) TestreadPublicKey() {
 	file, err := os.Open(suite.publicKey.Name())
-	defer file.Close()
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer file.Close()
 	publicKey, err := readPublicKey(file)
 	assert.NoError(suite.T(), err)
 	suite.Equal(publicKey, suite.pubKeyData)
 
 	malformedKey := "-----BEGIN CRYPT4GH PUBLIC KEY-----\nvery bad\n-----END CRYPT4GH PUBLIC KEY-----"
 	badFile := strings.NewReader(malformedKey)
-	publicKey, err = readPublicKey(badFile)
+	_, err = readPublicKey(badFile)
 	assert.EqualError(suite.T(), err, "malformed key file")
 }
 

--- a/list/list.go
+++ b/list/list.go
@@ -24,7 +24,7 @@ import (
 var Usage = `
 USAGE: %s list -config <s3config-file> [prefix]
 
-List: Lists recursively all files under the user's folder in the Sensitive Data Archive (SDA). 
+list: Lists recursively all files under the user's folder in the Sensitive Data Archive (SDA). 
       If the [prefix] parameter is used, only the files under the specified path will be returned.
 `
 

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -28,7 +28,7 @@ import (
 var Usage = `
 USAGE: %s upload -config <s3config-file> (--encrypt-with-key <public-key-file>) (-r) [file(s)|folder(s)] (-targetDir <upload-directory>)
 
-Upload: Uploads files to the Sensitive Data Archive (SDA). All files to upload
+upload: Uploads files to the Sensitive Data Archive (SDA). All files to upload
         are required to be encrypted and have the .c4gh file extension.
 `
 

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -48,7 +48,7 @@ var dirUpload = Args.Bool("r", false, "Upload directories recursively.")
 
 var targetDir = Args.String("targetDir", "", "Upload files|folders into this directory. If flag is omitted, all data will be uploaded in the user's base directory.")
 
-var pubKeyPath = Args.String("encrypt-with-key", "", "Public key to use for encryption of files before upload. The argument list may include only unencrypted data if this flag is set.")
+var pubKeyPath = Args.String("encrypt-with-key", "", "Public key file to use for encryption of files before upload. The key file may optionally contain several\n concatenated public keys. The argument list may include only unencrypted data if this flag is set.")
 
 // Config struct for storing the s3cmd file values
 type Config struct {


### PR DESCRIPTION
This PR adds multiple key encryption capability to `encrypt`, in summary the following functionality is added:

- input multiple public keys in the command prompt by using the -key flag repeatedly. This behavior mimics that of the crypt4gh tool

- an argument to -key can be a file with concatenated C4GH public keys and `encrypt` will parse and use them for encryption

- encrypt performs an early basic check and discards key files with invalid key format by reading the first few bytes of the given  file. This ensures that any mistakes of passing a wrong file as key file are avoided.

- multiple key encryption is also enabled for the `-encrypt-with-key` feature of the `upload` module  via passing a file with concatenated public keys as argument (and letting `encrypt` work on it in the background). Multiple `-encrypt-with-key` flag calls seemed to me like a superfluous feature for `upload` so it was not implemented for that module by choice.

Some refactoring regarding how the key is read was done and a few new functions were added to implement the feature. The go test suite, integration tests and readme files were also updated accordingly.

Closes [#534](https://github.com/NBISweden/LocalEGA-SE-Deployment/issues/534)