### PR TITLE
Bugfix/download behavior on s3 error

### DIFF
--- a/.github/integration/tests/tests.sh
+++ b/.github/integration/tests/tests.sh
@@ -269,8 +269,29 @@ else
     exit 1
 fi
 
+# Check that Download handles http responses with error status code
 
-# Download files using a url to urls_list.txt
+# Try downloading nonexistent file
+printf "%s" "Attempting to download a nonexistent file from S3..."
+errorMessage="reason: request failed with \`404 Not Found\`, details: {Code:NoSuchKey"
+if ./sda-cli download -outdir downloads http://localhost:9000/download/imaginary/path/ 2>&1 | grep -q "$errorMessage"; then
+    echo "bad download request handled properly"
+else
+    echo "Failed to handle bad download request"
+    exit 1
+fi
+
+# Try downloading from private bucket
+printf "%s" "Attempting to download from S3 bucket with ACL=private..."
+errorMessage="reason: request failed with \`403 Forbidden\`, details: {Code:AllAccessDisabled"
+if ./sda-cli download -outdir downloads http://localhost:9000/minio/test/dummy/data_file1.c4gh 2>&1 | grep -q "$errorMessage"; then
+    echo "bad download request handled properly"
+else
+    echo "Failed to handle bad download request"
+    exit 1
+fi
+
+# Download files using a folder url
 ./sda-cli download -outdir downloads http://localhost:9000/download/A352764B-2KB4-4738-B6B5-BA55D25FB469/
 
 if [ -f downloads/data_file.c4gh ]; then
@@ -282,7 +303,7 @@ fi
 
 rm -r downloads
 
-# Download files using a folder url
+# Download files using a url to urls_list.txt
 ./sda-cli download -outdir downloads http://localhost:9000/download/A352764B-2KB4-4738-B6B5-BA55D25FB469/urls_list.txt
 
 if [ -f downloads/data_file.c4gh ]; then

--- a/README.md
+++ b/README.md
@@ -178,12 +178,12 @@ where `<keypair_name>` is the base name of the key files. This command will crea
 
 ### Download file
 
-The `sda-cli` tool allows for downloading file(s)/datasets. The whole dataset is stored in a file named `urls_list.txt`. Using this file or the URL where it is stored, it is possible to download the files. There are three different ways to pass the location of the file to the tool, similar to the [dataset size section](#get-dataset-size):
-1. a URL to the file containing the locations of the dataset files
-2. a URL to a folder containing the `urls_list.txt` file with the locations of the dataset files
+The `sda-cli` tool allows for downloading file(s)/datasets. The URLs of the respective dataset files that are available for downloading are stored in a file named `urls_list.txt`. `sda-cli` allows to download files only by using such a file or the URL where it is stored. There are three different ways to pass the location of the file to the tool, similar to the [dataset size section](#get-dataset-size):
+1. a direct URL to `urls_list.txt` or a file with a different name but containing the locations of the dataset files
+2. a URL to a folder containing the `urls_list.txt` file
 3. the path to a local file containing the locations of the dataset files.
 
-Given this argument, the dataset can be retrieved using the following command:
+Given this argument, the whole dataset can be retrieved using the following command:
 ```bash
 ./sda-cli download <urls_file>
 ```
@@ -192,6 +192,7 @@ The tool also allows for selecting a folder where the files will be downloaded, 
 ```bash
 ./sda-cli download -outdir <outdir> <urls_file>
 ```
+**Note**: If needed, the user can download a selection of files from an available dataset by providing a customized `urls_list.txt` file.
 
 ## Decrypt file
 

--- a/download/download.go
+++ b/download/download.go
@@ -19,14 +19,14 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help download` command
 var Usage = `
-USAGE: %s download (-outdir <dir>) [url(s) | file]
+USAGE: %s download (-outdir <dir>) [url | file]
 
-download: Downloads files from the Sensitive Data Archive (SDA). The files will
-	  be downloaded in the current directory, if outdir is not defined.
-	  If a directory is provided (ending with "/"), then the tool will attempt
-	  to first download the urls_list.txt file, and then download all files in
-	  this list. If file urls are given, they files will be downloaded creating
-	  the same folder structure locally.
+download: Downloads files from the Sensitive Data Archive (SDA). A list with urls
+	  for files to download must be provided either as a url directly to a remote
+	  url_list.txt file or to its containing directory (ending with "/").
+	  Alternatively, the local path to such a file may be given, instead.
+	  The files will be downloaded in the current directory, if outdir is not
+	  defined and their folder structure is preserved.
 `
 
 // ArgHelp is the suffix text that will be displayed after the argument list in

--- a/download/download.go
+++ b/download/download.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/NBISweden/sda-cli/helpers"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -75,6 +76,16 @@ func downloadFile(url string, filePath string) error {
 		return fmt.Errorf("failed to download file, reason: %v", err)
 	}
 	defer resp.Body.Close()
+
+	// Check reponse status and report S3 error response
+	if resp.StatusCode >= 400 {
+		errorDetails, err := helpers.ParseS3ErrorResponse(resp.Body)
+		if err != nil {
+			log.Error(err.Error())
+		}
+
+		return fmt.Errorf("request failed with `%s`, details: %v", resp.Status, errorDetails)
+	}
 
 	// Create the file in the current location
 	out, err := os.Create(filePath)


### PR DESCRIPTION
This PR fixes a bug in download which is described in #118. The fix adds handling of http errors (status code `>=400`). In case of such an error, download will now exit before writing  to a `urls_list.txt` file and will print the error status code in the error message. In addition, it will check whether the response is xml encoded, as is the case for S3, and if yes it will unmarshal the xml and append the S3 report to the returned error message.
Summary of changes:
- adds a new helper function that reports error messages read from xml
- adds a respective helper struct for unmarshalling of xml error messages
- updates the `helpers` and `download` testsuite with more tests
- adds integration tests
- updates text of download usage and respective readme for more clarity

Closes #118