### PR TITLE
Fix releaser bug on multiple archives

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,15 +15,16 @@ builds:
       - goarch: 386
       - goarch: arm
 archives:
-  - format_overrides:
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{ .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+    format_overrides:
       - goos: windows
         format: zip
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/README.md
+++ b/README.md
@@ -221,3 +221,9 @@ The github actions include a release workflow that builds binaries for different
 
 In order for the automatic release to get triggered, the releases should be of the format `vX.X.X`, e.g. `v1.0.0`.
 
+## Update releaser
+
+Before pushing a change to the releaser, make sure to run the check for the configuration file, running:
+```sh
+goreleaser check -f .goreleaser.yaml
+```


### PR DESCRIPTION
The pull request if fixing the issue with the previous PR, which broke the releases, and solves the issue with creating `zip` instead of `tar` files for windows users. 

Also includes a small README update on checking the configuration file for the releaser.