### PR TITLE
fix: wrong path separator used on windows

### DIFF
--- a/download/download.go
+++ b/download/download.go
@@ -56,7 +56,7 @@ func createFilePathFromURL(file string, baseDir string) (fileName string, err er
 	fileName = filepath.Join(baseDir, match[1])
 
 	var filePath string
-	if strings.Contains(fileName, "/") {
+	if strings.Contains(fileName, string(os.PathSeparator)) {
 		filePath = filepath.Dir(fileName)
 		err = os.MkdirAll(filePath, os.ModePerm)
 		if err != nil {


### PR DESCRIPTION
Fixes the bug we saw where files could not be downloaded on windows.