### PR TITLE
hotfix: translate windows path separators to "/"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ personal/
 
 # compiled binary
 sda-cli
+sda-cli.exe
 
 dist/

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -247,6 +247,21 @@ func (suite *TestSuite) TestcreateFilePaths() {
 	assert.ErrorContains(suite.T(), err, "no such file or directory")
 }
 
+func (suite *TestSuite) TestFormatUploadFilePath() {
+
+	unixPath := "a/b/c.c4gh"
+	testPath := filepath.Join("a", "b", "c.c4gh")
+	uploadPath := formatUploadFilePath(testPath)
+
+	assert.Equal(suite.T(), unixPath, uploadPath)
+
+	weirdPath := "a/b:/c;.c4gh"
+	goodPath := "a/b_/c_.c4gh"
+	formattedPath := formatUploadFilePath(weirdPath)
+
+	assert.Equal(suite.T(), goodPath, formattedPath)
+}
+
 func (suite *TestSuite) TestFunctionality() {
 
 	// Create a fake s3 backend


### PR DESCRIPTION
Fixes the bug where windows path separators are uploaded as-is, and confusing S3.

Closes #161 