### PR TITLE
Fix latest batch of user errors

### DIFF
--- a/.github/integration/tests/tests.sh
+++ b/.github/integration/tests/tests.sh
@@ -49,7 +49,7 @@ check_encypted_file $files
 ./sda-cli upload -config testing/s3cmd.conf data_file.c4gh
 check_uploaded_file test/dummy/data_file.c4gh data_file.c4gh
 
-output=$(./sda-cli list -config testing/s3cmd.conf 2>&1 >/dev/null | grep -q "data_file.c4gh")
+output=$(./sda-cli list -config testing/s3cmd.conf | grep -q "data_file.c4gh")
 
 if $output ; then
     echo "Listed file from s3 backend"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,14 @@ jobs:
           - windows-latest
     steps:
 
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
         id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
 
       - name: Get dependencies
         run: |

--- a/create_key/create_key.go
+++ b/create_key/create_key.go
@@ -1,4 +1,4 @@
-package createKey
+package createkey
 
 import (
 	"errors"

--- a/create_key/create_key_test.go
+++ b/create_key/create_key_test.go
@@ -1,4 +1,4 @@
-package createKey
+package createkey
 
 import (
 	"fmt"

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -65,6 +65,7 @@ func init() {
 // Encrypt takes a set of arguments, parses them, and attempts to encrypt the
 // given data files with the given public key file
 func Encrypt(args []string) error {
+	publicKeyFileList = nil
 	// Parse flags.
 	err := Args.Parse(args[1:])
 	if err != nil {

--- a/list/list.go
+++ b/list/list.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/inhies/go-bytesize"
-	log "github.com/sirupsen/logrus"
 )
 
 // Help text and command line flags.
@@ -106,7 +105,7 @@ func List(args []string) error {
 
 	for i := range result.Contents {
 		file := *result.Contents[i].Key
-		log.Printf("%s \t %s \n", bytesize.New(float64((*result.Contents[i].Size))), file[strings.Index(file, "/")+1:])
+		fmt.Printf("%s \t %s \n", bytesize.New(float64((*result.Contents[i].Size))), file[strings.Index(file, "/")+1:])
 	}
 
 	return nil

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -251,6 +251,8 @@ func formatUploadFilePath(filePath string) string {
 func Upload(args []string) error {
 	var files []string
 	var outFiles []string
+	*pubKeyPath = ""
+	*targetDir = ""
 
 	// Shift flag and their arguments from the end to the beginning
 	// if more boolean flags are added in the future the following needs a slight modification

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -99,7 +99,7 @@ func LoadConfigFile(path string) (*Config, error) {
 
 	// Where 15 is the default chunk size of the library
 	if config.MultipartChunkSizeMb <= 15 {
-		config.MultipartChunkSizeMb = 50
+		config.MultipartChunkSizeMb = 15
 	}
 
 	return config, nil

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -358,10 +358,5 @@ func Upload(args []string) error {
 		}
 	}
 
-	// Upload files
-	if err = uploadFiles(files, outFiles, filepath.ToSlash(*targetDir), config); err != nil {
-		return err
-	}
-
-	return nil
+	return uploadFiles(files, outFiles, filepath.ToSlash(*targetDir), config)
 }

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -359,7 +359,7 @@ func Upload(args []string) error {
 	}
 
 	// Upload files
-	if err = uploadFiles(files, outFiles, *targetDir, config); err != nil {
+	if err = uploadFiles(files, outFiles, filepath.ToSlash(*targetDir), config); err != nil {
 		return err
 	}
 

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -271,7 +271,7 @@ func Upload(args []string) error {
 	info, err := os.Stat(*targetDir)
 
 	// Dereference the pointer to a string
-	targetDirString := ""
+	var targetDirString string
 	if targetDir != nil {
 		targetDirString = *targetDir
 	}

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -95,8 +95,7 @@ access_key = someUser
 
 	defer os.Remove(configPath.Name())
 
-	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
-	if err != nil {
+	if err := os.WriteFile(configPath.Name(), []byte(confFile), 0600); err != nil {
 		log.Printf("failed to write temp config file, %v", err)
 	}
 
@@ -170,18 +169,15 @@ func (suite *TestSuite) TestSampleNoFiles() {
 	// Test Upload function
 	os.Args = []string{"upload", "-config", configPath.Name()}
 
-	err = Upload(os.Args)
-	assert.EqualError(suite.T(), err, "no files to upload")
+	assert.EqualError(suite.T(), Upload(os.Args), "no files to upload")
 
 	// Test handling of mistakenly passing a filename as an upload folder
 	os.Args = []string{"upload", "-config", configPath.Name(), "-targetDir", configPath.Name()}
-	err = Upload(os.Args)
-	assert.EqualError(suite.T(), err, configPath.Name()+" is not a valid target directory")
+	assert.EqualError(suite.T(), Upload(os.Args), configPath.Name()+" is not a valid target directory")
 
 	// Test handling of mistakenly passing a flag as an upload folder
 	os.Args = []string{"upload", "-config", configPath.Name(), "-targetDir", "-r"}
-	err = Upload(os.Args)
-	assert.EqualError(suite.T(), err, "-r"+" is not a valid target directory")
+	assert.EqualError(suite.T(), Upload(os.Args), "-r"+" is not a valid target directory")
 
 	// Test passing flags at the end as well
 
@@ -190,12 +186,10 @@ func (suite *TestSuite) TestSampleNoFiles() {
 		msg = "CreateFile somefileOrfolder: The system cannot find the file specified."
 	}
 	os.Args = []string{"upload", "-config", configPath.Name(), "-r", "somefileOrfolder", "-targetDir", "somedir"}
-	err = Upload(os.Args)
-	assert.EqualError(suite.T(), err, msg)
+	assert.EqualError(suite.T(), Upload(os.Args), msg)
 
 	os.Args = []string{"upload", "-config", configPath.Name(), "somefiles", "-targetDir"}
-	err = Upload(os.Args)
-	assert.EqualError(suite.T(), err, "-config is not a valid target directory")
+	assert.EqualError(suite.T(), Upload(os.Args), "-config is not a valid target directory")
 
 	// Test uploadFiles function
 	config, _ := LoadConfigFile(configPath.Name())
@@ -361,8 +355,7 @@ func (suite *TestSuite) TestFunctionality() {
 
 	// Test recursive upload
 	os.Args = []string{"upload", "-config", configPath.Name(), "-r", dir}
-	err = Upload(os.Args)
-	assert.NoError(suite.T(), err)
+	assert.NoError(suite.T(), Upload(os.Args))
 
 	// Check logs that file was uploaded
 	logMsg := fmt.Sprintf("%v", strings.TrimSuffix(str.String(), "\n"))
@@ -412,16 +405,14 @@ func (suite *TestSuite) TestFunctionality() {
 		log.Panic("Cannot create temporary public key file", err)
 	}
 
-	err = keys.WriteCrypt4GHX25519PublicKey(publicKey, pubKeyData)
-	if err != nil {
+	if err = keys.WriteCrypt4GHX25519PublicKey(publicKey, pubKeyData); err != nil {
 		log.Panicf("failed to write temporary public key file, %v", err)
 	}
 
 	// Empty buffer logs
 	str.Reset()
 	newArgs := []string{"upload", "-config", configPath.Name(), "--encrypt-with-key", publicKey.Name(), testfile.Name(), "-targetDir", "someDir"}
-	err = Upload(newArgs)
-	assert.NoError(suite.T(), err)
+	assert.NoError(suite.T(), Upload(newArgs))
 
 	// Check logs that encrypted file was uploaded
 	logMsg = fmt.Sprintf("%v", strings.TrimSuffix(str.String(), "\n"))
@@ -443,20 +434,17 @@ func (suite *TestSuite) TestFunctionality() {
 
 	// Check that trying to encrypt already encrypted files returns error and aborts
 	newArgs = []string{"upload", "-config", configPath.Name(), "--encrypt-with-key", publicKey.Name(), dir, "-r"}
-	err = Upload(newArgs)
-	assert.EqualError(suite.T(), err, "aborting")
+	assert.EqualError(suite.T(), Upload(newArgs), "aborting")
 
 	// Check handling of passing source files as pub key
 	// (code checks first for errors related with file args)
 	newArgs = []string{"upload", "-config", configPath.Name(), "--encrypt-with-key", testfile.Name()}
-	err = Upload(newArgs)
-	assert.EqualError(suite.T(), err, "no files to upload")
+	assert.EqualError(suite.T(), Upload(newArgs), "no files to upload")
 
 	// If both a bad key and already encrypted file args are given,
 	// file arg errors are captured first
 	newArgs = []string{"upload", "-config", configPath.Name(), "--encrypt-with-key", "somekey", testfile.Name()}
-	err = Upload(newArgs)
-	assert.EqualError(suite.T(), err, "aborting")
+	assert.EqualError(suite.T(), Upload(newArgs), "aborting")
 
 	// Remove hash files created by Encrypt
 	if err := os.Remove("checksum_encrypted.md5"); err != nil {

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -379,13 +379,13 @@ func (suite *TestSuite) TestFunctionality() {
 	assert.Equal(suite.T(), aws.StringValue(result.Contents[0].Key), fmt.Sprintf("%s/%s", filepath.Base(dir), filepath.Base(testfile.Name())))
 
 	// Test upload to a different folder
-	os.Args = []string{"upload", "-config", configPath.Name(), testfile.Name(), "-targetDir", "a"}
-	err = Upload(os.Args)
-	assert.NoError(suite.T(), err)
+	targetPath := filepath.Join("a", "b", "c")
+	os.Args = []string{"upload", "-config", configPath.Name(), testfile.Name(), "-targetDir", targetPath}
+	assert.NoError(suite.T(), Upload(os.Args))
 
 	// Check logs that file was uploaded
 	logMsg = fmt.Sprintf("%v", strings.TrimSuffix(str.String(), "\n"))
-	msg = fmt.Sprintf("file uploaded to %s/dummy/a/%s", ts.URL, filepath.Base(testfile.Name()))
+	msg = fmt.Sprintf("file uploaded to %s/dummy/%s/%s", ts.URL, filepath.ToSlash(targetPath), filepath.Base(testfile.Name()))
 	assert.Contains(suite.T(), logMsg, msg)
 
 	// Check that file showed up in the s3 bucket correctly
@@ -395,7 +395,7 @@ func (suite *TestSuite) TestFunctionality() {
 	if err != nil {
 		log.Panic(err.Error())
 	}
-	assert.Equal(suite.T(), aws.StringValue(result.Contents[0].Key), fmt.Sprintf("a/%s", filepath.Base(testfile.Name())))
+	assert.Equal(suite.T(), aws.StringValue(result.Contents[0].Key), fmt.Sprintf("%s/%s", filepath.ToSlash(targetPath), filepath.Base(testfile.Name())))
 
 	// Test encrypt-with-key on upload.
 	// Tests specific to encrypt module are not repeated here.


### PR DESCRIPTION
* Converts windows pat to unix when using the `-targetDir` option, tests on windows by using `filepath.join()`
* sets correct MultipartChunkSizeMb if set below 15MB
* Fixes some linter issues
* print to stdout instead of log when listing uploads

Fixes: #188 #187