### PR TITLE
allow parsing simple s3cmd config files

### DIFF
--- a/upload/upload.go
+++ b/upload/upload.go
@@ -77,7 +77,15 @@ func LoadConfigFile(path string) (*Config, error) {
 		return config, err
 	}
 
-	if err := cfg.Section("").MapTo(config); err != nil {
+	// ini sees a DEFAULT section by default
+	var iniSection string
+	if len(cfg.SectionStrings()) > 1 {
+		iniSection = cfg.SectionStrings()[1]
+	} else {
+		iniSection = cfg.SectionStrings()[0]
+	}
+
+	if err := cfg.Section(iniSection).MapTo(config); err != nil {
 		return nil, err
 	}
 

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -70,6 +70,32 @@ encrypt = False
 	assert.EqualError(suite.T(), err, "key-value delimiter not found: guess_mime_type!True\n")
 }
 
+func (suite *TestSuite) TestConfigS3cmdFileFormat() {
+	var confFile = `
+	[some header]
+	access_token = someToken
+	host_base = someHostBase
+	host_bucket = someHostBase
+	secret_key = someUser
+	access_key = someUser
+`
+
+	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd-")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer os.Remove(configPath.Name())
+
+	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
+	if err != nil {
+		log.Printf("failed to write temp config file, %v", err)
+	}
+
+	_, err = LoadConfigFile(configPath.Name())
+	assert.NoError(suite.T(), err)
+}
+
 func (suite *TestSuite) TestConfigMissingCredentials() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd-")


### PR DESCRIPTION
This fix allows for s3cmd conf files to be parsed correctly by `sda-cli` if the file has none or one header. 

By default the `go-ini` library used to parse the s3conf file always assumes a `[DEFAULT]` header even when the file has none. In case the file itself  has (for any reason) more than one headers (i.e. `ini` sections), `sda-cli` will parse only the section that corresponds to the first one.

Closes #182. 