### PR TITLE
#199: make argument position irrelevant

### DIFF
--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -44,9 +44,11 @@ var privateKeyFile = Args.String("key", "",
 // Decrypt takes a set of arguments, parses them, and attempts to decrypt the
 // given data files with the given private key file..
 func Decrypt(args []string) error {
-	err := Args.Parse(args[1:])
+
+	// Call ParseArgs to take care of all the flag parsing
+	err := helpers.ParseArgs(args, Args)
 	if err != nil {
-		return fmt.Errorf("argument parsing failed, reason: %v", err)
+		return err
 	}
 
 	// format input and output files

--- a/download/download.go
+++ b/download/download.go
@@ -156,11 +156,11 @@ func GetURLsListFile(currentPath string, fileLocation string) (urlsFilePath stri
 // Download function downloads the files included in the urls_list.txt file.
 // The argument can be a local file or a url to an S3 folder
 func Download(args []string) error {
-	// Parse flags. There are no flags at the moment, but in case some are added
-	// we check for them.
-	err := Args.Parse(args[1:])
+
+	// Call ParseArgs to take care of all the flag parsing
+	err := helpers.ParseArgs(args, Args)
 	if err != nil {
-		return fmt.Errorf("failed parsing arguments, reason: %v", err)
+		return err
 	}
 
 	// Args() returns the non-flag arguments, which we assume are filenames.

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -65,11 +65,12 @@ func init() {
 // Encrypt takes a set of arguments, parses them, and attempts to encrypt the
 // given data files with the given public key file
 func Encrypt(args []string) error {
+
 	publicKeyFileList = nil
-	// Parse flags.
-	err := Args.Parse(args[1:])
+	// Call ParseArgs to take care of all the flag parsing
+	err := helpers.ParseArgs(args, Args)
 	if err != nil {
-		return fmt.Errorf("could not parse arguments: %s", err)
+		return err
 	}
 
 	// Exit if public key is not provided

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"encoding/xml"
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -106,6 +107,34 @@ func ParseS3ErrorResponse(respBody io.Reader) (string, error) {
 	}
 
 	return fmt.Sprintf("%+v", xmlErrorResponse), nil
+}
+
+// Removes all positional arguments from os.Args, and returns them.
+// This function assumes that all flags have exactly one value.
+func getPositional() (positional []string) {
+	i := 1
+	for i < len(os.Args) {
+		if os.Args[i][0] == '-' {
+			// if the current arg is a flag, skip the flag and its value
+			i += 2
+		} else {
+			// if the current arg is positional, remove it and add it to
+			// `positional`
+			positional = append(positional, os.Args[i])
+			os.Args = append(os.Args[:i], os.Args[i+1:]...)
+		}
+	}
+
+	return positional
+}
+
+func ParseArgs(args []string, argFlags *flag.FlagSet) error {
+	var pos = getPositional()
+	// append positional args back at the end of os.Args
+	os.Args = append(os.Args, pos...)
+	err := argFlags.Parse(args[1:])
+
+	return err
 }
 
 //

--- a/list/list.go
+++ b/list/list.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/NBISweden/sda-cli/helpers"
 	"github.com/NBISweden/sda-cli/upload"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -66,10 +67,10 @@ func listFiles(config *upload.Config, prefix string) (result *s3.ListObjectsV2Ou
 
 // List function lists the contents of an s3
 func List(args []string) error {
-
-	err := Args.Parse(args[1:])
+	// Call ParseArgs to take care of all the flag parsing
+	err := helpers.ParseArgs(args, Args)
 	if err != nil {
-		return fmt.Errorf("failed parsing arguments, reason: %v", err)
+		return err
 	}
 
 	prefix := ""


### PR DESCRIPTION
Make the order of the flags and arguments irrelevant when using the modules decrypt, download, encrypt, list.
The code from the upload module that handled this previously was moved to helpers.