### PR TITLE
Fix/reflow usage texts

### DIFF
--- a/create_key/create_key.go
+++ b/create_key/create_key.go
@@ -34,13 +34,14 @@ createKey:
 // the module help.
 var ArgHelp = `
     [name]
-        The basename of the keyfiles to generate`
+        The basename of the keyfiles to generate.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help
 var Args = flag.NewFlagSet("createKey", flag.ExitOnError)
 
-var outDir = Args.String("outdir", "", "Output directory for the key files")
+var outDir = Args.String("outdir", "",
+	"Output directory for the key files.")
 
 // CreateKey takes two arguments, a base filename, and optionally an output
 // directory specified with `-outdir`.

--- a/create_key/create_key.go
+++ b/create_key/create_key.go
@@ -20,17 +20,20 @@ import (
 var Usage = `
 USAGE: %s createKey (-outdir <dirname>) <name>
 
-createKey: Creates a crypt4gh encryption key pair, and saves it to
-           <name>.pub.pem, and <name>.sec.pem.
-           NOTE: keys created using this function should not be used when
-           encrypting submission files, they should only be used for decrypting
-           files downloaded from the archive.
+createKey:
+    Creates a crypt4gh encryption key pair, and saves it to
+    <name>.pub.pem, and <name>.sec.pem.
+
+    NOTE:
+        Keys created using this function should not be used when
+        encrypting submission files, they should only be used for
+        decrypting files downloaded from the archive.
 `
 
 // ArgHelp is the suffix text that will be displayed after the argument list in
 // the module help.
 var ArgHelp = `
-  [name]
+    [name]
         The basename of the keyfiles to generate`
 
 // Args is a flagset that needs to be exported so that it can be written to the

--- a/datasetsize/datasetsize.go
+++ b/datasetsize/datasetsize.go
@@ -20,17 +20,19 @@ import (
 var Usage = `
 USAGE: %s datasetsize [url(s) | file]
 
-datasetsize: List files that can be downloaded from the Sensitive Data Archive (SDA).
-	  If a URL is provided (ending with "/" or the urls_list.txt file), then the tool 
-	  will attempt to first download the urls_list.txt file, and then return a list 
-	  of the files with their respective sizes.
+datasetsize:
+    List files that can be downloaded from the Sensitive Data
+    Archive (SDA).  If a URL is provided (ending with "/" or the
+    urls_list.txt file), then the tool will attempt to first download
+    the urls_list.txt file, and then return a list of the files with
+    their respective sizes.
 `
 
 // ArgHelp is the suffix text that will be displayed after the argument list in
 // the module help
 var ArgHelp = `
-  [url]
-        the first flagless argument will be used as file location.`
+    [url]
+        The first flagless argument will be used as file location.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -22,17 +22,18 @@ import (
 var Usage = `
 USAGE: %s decrypt -key <private-key-file> [file(s)]
 
-decrypt: Decrypts files from the Sensitive Data Archive (SDA) with the provided
-         private key. If the private key is encrypted, the password can be
-         supplied in the C4GH_PASSWORD environment variable, or at the interactive
-         password prompt.
+decrypt:
+    Decrypts files from the Sensitive Data Archive (SDA) with the
+    provided private key.  If the private key is encrypted, the password
+    can be supplied in the C4GH_PASSWORD environment variable, or at the
+    interactive password prompt.
 `
 
 // ArgHelp is the suffix text that will be displayed after the argument list in
 // the module help
 var ArgHelp = `
-  [file(s)]
-        all flagless arguments will be used as filenames for decryption.`
+    [file(s)]
+        All flagless arguments will be used as filenames for decryption.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/download/download.go
+++ b/download/download.go
@@ -41,7 +41,8 @@ var ArgHelp = `
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help
 var Args = flag.NewFlagSet("download", flag.ExitOnError)
-var outDir = Args.String("outdir", "", "Directory for downloaded files")
+var outDir = Args.String("outdir", "",
+	"Directory for downloaded files.")
 
 // Gets the file name for a URL, using regex
 func createFilePathFromURL(file string, baseDir string) (fileName string, err error) {

--- a/download/download.go
+++ b/download/download.go
@@ -22,19 +22,21 @@ import (
 var Usage = `
 USAGE: %s download (-outdir <dir>) [url | file]
 
-download: Downloads files from the Sensitive Data Archive (SDA). A list with urls
-	  for files to download must be provided either as a url directly to a remote
-	  url_list.txt file or to its containing directory (ending with "/").
-	  Alternatively, the local path to such a file may be given, instead.
-	  The files will be downloaded in the current directory, if outdir is not
-	  defined and their folder structure is preserved.
+download:
+    Downloads files from the Sensitive Data Archive (SDA).  A list with
+    URLs for files to download must be provided either as a URL directly
+    to a remote url_list.txt file or to its containing directory
+    (ending with "/"). Alternatively, the local path to such a file may
+    be given, instead.  The files will be downloaded in the current
+    directory, if outdir is not defined and their folder structure is
+    preserved.
 `
 
 // ArgHelp is the suffix text that will be displayed after the argument list in
 // the module help
 var ArgHelp = `
-  [urls]
-        all flagless arguments will be used as download urls.`
+    [urls]
+        All flagless arguments will be used as download URLs.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -28,21 +28,22 @@ import (
 var Usage = `
 USAGE: %s encrypt -key <public-key-file> (-outdir <dir>) (-continue=true) [file(s)]
 
-encrypt: Encrypts files according to the crypt4gh standard used in the Sensitive
-         Data Archive (SDA). Each given file will be encrypted and written to
-         <filename>.c4gh. Both encrypted and unencrypted checksums will be
-         calculated and written to:
-          - checksum_unencrypted.md5
-          - checksum_encrypted.md5
-          - checksum_unencrypted.sha256
-          - checksum_encrypted.sha256
+encrypt:
+    Encrypts files according to the crypt4gh standard used in the
+    Sensitive Data Archive (SDA).  Each given file will be encrypted
+    and written to <filename>.c4gh.  Both encrypted and unencrypted
+    checksums will be calculated and written to:
+        - checksum_unencrypted.md5
+        - checksum_encrypted.md5
+        - checksum_unencrypted.sha256
+        - checksum_encrypted.sha256
 `
 
 // ArgHelp is the suffix text that will be displayed after the argument list in
 // the module help
 var ArgHelp = `
-  [files]
-        all flagless arguments will be used as filenames for encryption.`
+    [files]
+        All flagless arguments will be used as filenames for encryption.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -49,7 +49,8 @@ var ArgHelp = `
 // main program help
 var Args = flag.NewFlagSet("encrypt", flag.ExitOnError)
 
-var outDir = Args.String("outdir", "", "Output directory for encrypted files")
+var outDir = Args.String("outdir", "",
+	"Output directory for encrypted files.")
 
 var continueEncrypt = Args.Bool("continue", false, "Do not exit on file errors but skip and continue.")
 

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -70,11 +70,8 @@ func FormatSubcommandUsage(usageString string) string {
 	}
 	// reformat lines
 	usage := lines[0]
-	helpStart := lines[2]
-	indent := strings.Index(helpStart, " ")
-	format := "\n%s\n\n%" + fmt.Sprintf("%v", indent+1) + "s%s\n\n"
 
-	return fmt.Sprintf(format, strings.Join(lines[2:], "\n"), " ", usage)
+	return fmt.Sprintf("\n%s\n\n    %s\n\n", strings.Join(lines[2:], "\n"), usage)
 }
 
 // PromptPassword creates a user prompt for inputting passwords, where all

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -109,14 +109,16 @@ func (suite *HelperTests) TestFormatSubcommandUsage() {
 
 	correctUsage := `USAGE: %s module <args>
 
-module: this module does all the fancies stuff,
-        and virtually none of the non-fancy stuff.`
+module:
+    this module does all the fancies stuff,
+    and virtually none of the non-fancy stuff.`
 
 	correctFormat := fmt.Sprintf(`
-module: this module does all the fancies stuff,
-        and virtually none of the non-fancy stuff.
+module:
+    this module does all the fancies stuff,
+    and virtually none of the non-fancy stuff.
 
-        USAGE: %s module <args>
+    USAGE: %s module <args>
 
 `, os.Args[0])
 	testCorrect := FormatSubcommandUsage(correctUsage)

--- a/list/list.go
+++ b/list/list.go
@@ -39,7 +39,8 @@ var ArgHelp = `
 // main program help
 var Args = flag.NewFlagSet("list", flag.ExitOnError)
 
-var configPath = Args.String("config", "", "S3 config file to use for listing.")
+var configPath = Args.String("config", "",
+	"S3 config file to use for listing.")
 
 func listFiles(config *upload.Config, prefix string) (result *s3.ListObjectsV2Output, err error) {
 	sess := session.Must(session.NewSession(&aws.Config{

--- a/list/list.go
+++ b/list/list.go
@@ -23,15 +23,17 @@ import (
 var Usage = `
 USAGE: %s list -config <s3config-file> [prefix]
 
-list: Lists recursively all files under the user's folder in the Sensitive Data Archive (SDA). 
-      If the [prefix] parameter is used, only the files under the specified path will be returned.
+list:
+    Lists recursively all files under the user's folder in the Sensitive
+    Data Archive (SDA).  If the [prefix] parameter is used, only the
+    files under the specified path will be returned.
 `
 
 // ArgHelp is the suffix text that will be displayed after the argument list in
 // the module help
 var ArgHelp = `
-  [prefix]
-        the location/folder of the s3 to list contents`
+    [prefix]
+        The location/folder of the s3 to list contents.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func Help(command string) {
 	info, isLegal := Commands[command]
 	if isLegal {
 		// print subcommand help
-		fmt.Fprintf(os.Stderr, info.usage + "\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, info.usage+"\n", os.Args[0])
 		fmt.Fprintln(os.Stderr, "Command line arguments:")
 		info.args.PrintDefaults()
 		fmt.Fprintln(os.Stderr, info.argHelp)

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func Help(command string) {
 	info, isLegal := Commands[command]
 	if isLegal {
 		// print subcommand help
-		fmt.Fprintf(os.Stderr, info.usage, os.Args[0])
+		fmt.Fprintf(os.Stderr, info.usage + "\n", os.Args[0])
 		fmt.Fprintln(os.Stderr, "Command line arguments:")
 		info.args.PrintDefaults()
 		fmt.Fprintln(os.Stderr, info.argHelp)

--- a/main.go
+++ b/main.go
@@ -18,8 +18,8 @@ import (
 
 var Usage = `USAGE: %s <command> [command-args]
 
-This is a helper tool that can help with common tasks when interacting with the
-Sensitive Data Archive (SDA).
+This is a helper tool that can help with common tasks when interacting
+with the Sensitive Data Archive (SDA).
 `
 
 // Map of the sub-commands, and their arguments and usage text strings

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -31,15 +31,18 @@ import (
 var Usage = `
 USAGE: %s upload -config <s3config-file> (--encrypt-with-key <public-key-file>) (-r) [file(s)|folder(s)] (-targetDir <upload-directory>)
 
-upload: Uploads files to the Sensitive Data Archive (SDA). All files to upload
-        are required to be encrypted and have the .c4gh file extension.
+upload:
+    Uploads files to the Sensitive Data Archive (SDA).  All files
+    to upload are required to be encrypted and have the .c4gh file
+    extension.
 `
 
 // ArgHelp is the suffix text that will be displayed after the argument list in
 // the module help
 var ArgHelp = `
-  [file(s)|folder(s)]
-        all flagless arguments will be used as file or directory names to upload. Directories will be skipped if '-r' is not provided.`
+    [file(s)|folder(s)]
+        All flagless arguments will be used as file or directory names
+        to upload.  Directories will be skipped if '-r' is not provided.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -55,14 +55,14 @@ var dirUpload = Args.Bool("r", false,
 	"Upload directories recursively.")
 
 var targetDir = Args.String("targetDir", "",
-        "Upload files or folders into this directory.  If flag is omitted,\n" +
-        "all data will be uploaded in the user's base directory.")
+	"Upload files or folders into this directory.  If flag is omitted,\n"+
+		"all data will be uploaded in the user's base directory.")
 
 var pubKeyPath = Args.String("encrypt-with-key", "",
-        "Public key file to use for encryption of files before upload.\n" +
-        "The key file may optionally contain several concatenated\n" +
-        "public keys.  The argument list may include only unencrypted\n" +
-        "data if this flag is set.")
+	"Public key file to use for encryption of files before upload.\n"+
+		"The key file may optionally contain several concatenated\n"+
+		"public keys.  The argument list may include only unencrypted\n"+
+		"data if this flag is set.")
 
 // Config struct for storing the s3cmd file values
 type Config struct {

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -55,14 +55,14 @@ var dirUpload = Args.Bool("r", false,
 	"Upload directories recursively.")
 
 var targetDir = Args.String("targetDir", "",
-	"Upload files or folders into this directory.\n" +
-	"If flag is omitted, all data will be uploaded\n" +
-	"in the user's base directory.")
+        "Upload files or folders into this directory.  If flag is omitted,\n" +
+        "all data will be uploaded in the user's base directory.")
 
 var pubKeyPath = Args.String("encrypt-with-key", "",
-	"Public key file to use for encryption of files before upload.\n" +
-	"The key file may optionally contain several concatenated public keys.\n" +
-	"The argument list may include only unencrypted data if this flag is set.")
+        "Public key file to use for encryption of files before upload.\n" +
+        "The key file may optionally contain several concatenated\n" +
+        "public keys.  The argument list may include only unencrypted\n" +
+        "data if this flag is set.")
 
 // Config struct for storing the s3cmd file values
 type Config struct {

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -48,13 +48,21 @@ var ArgHelp = `
 // main program help
 var Args = flag.NewFlagSet("upload", flag.ExitOnError)
 
-var configPath = Args.String("config", "", "S3 config file to use for uploading.")
+var configPath = Args.String("config", "",
+	"S3 config file to use for uploading.")
 
-var dirUpload = Args.Bool("r", false, "Upload directories recursively.")
+var dirUpload = Args.Bool("r", false,
+	"Upload directories recursively.")
 
-var targetDir = Args.String("targetDir", "", "Upload files|folders into this directory. If flag is omitted, all data will be uploaded in the user's base directory.")
+var targetDir = Args.String("targetDir", "",
+	"Upload files or folders into this directory.\n" +
+	"If flag is omitted, all data will be uploaded\n" +
+	"in the user's base directory.")
 
-var pubKeyPath = Args.String("encrypt-with-key", "", "Public key file to use for encryption of files before upload. The key file may optionally contain several\n concatenated public keys. The argument list may include only unencrypted data if this flag is set.")
+var pubKeyPath = Args.String("encrypt-with-key", "",
+	"Public key file to use for encryption of files before upload.\n" +
+	"The key file may optionally contain several concatenated public keys.\n" +
+	"The argument list may include only unencrypted data if this flag is set.")
 
 // Config struct for storing the s3cmd file values
 type Config struct {

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -29,7 +29,7 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help download` command
 var Usage = `
-USAGE: %s upload -config <s3config-file> (--encrypt-with-key <public-key-file>) (-r) [file(s)|folder(s)] (-targetDir <upload-directory>)
+USAGE: %s upload -config <s3config-file> (--encrypt-with-key <public-key-file>) (-r) [file(s) | folder(s)] (-targetDir <upload-directory>)
 
 upload:
     Uploads files to the Sensitive Data Archive (SDA).  All files


### PR DESCRIPTION
This PR is related to #202 and improves the readability of the built-in command line documentation provided by `sda-cli`.

I made this PR due to a question in Slack, which required me to read the output of `sda-cli` and `sda-cli help upload`.  Reading this, I noticed that the text was formatted in a way that made it less easy to read.

This PR introduces a more consistent indentation and line length in the built-in documentation.

Before (`sda-cli help upload`):
```text
USAGE: ./sda-cli upload -config <s3config-file> (--encrypt-with-key <public-key-file>) (-r) [file(s)|folder(s)] (-targetDir <upload-directory>)

upload: Uploads files to the Sensitive Data Archive (SDA). All files to upload
        are required to be encrypted and have the .c4gh file extension.
Command line arguments:
  -config string
        S3 config file to use for uploading.
  -encrypt-with-key string
        Public key file to use for encryption of files before upload. The key file may optionally contain several
         concatenated public keys. The argument list may include only unencrypted data if this flag is set.
  -r    Upload directories recursively.
  -targetDir string
        Upload files|folders into this directory. If flag is omitted, all data will be uploaded in the user's base directory.

  [file(s)|folder(s)]
        all flagless arguments will be used as file or directory names to upload. Directories will be skipped if '-r' is not provided.
```


After:
```text
USAGE: ./sda-cli upload -config <s3config-file> (--encrypt-with-key <public-key-file>) (-r) [file(s) | folder(s)] (-targetDir <upload-directory>)

upload:
    Uploads files to the Sensitive Data Archive (SDA).  All files
    to upload are required to be encrypted and have the .c4gh file
    extension.

Command line arguments:
  -config string
        S3 config file to use for uploading.
  -encrypt-with-key string
        Public key file to use for encryption of files before upload.
        The key file may optionally contain several concatenated
        public keys.  The argument list may include only unencrypted
        data if this flag is set.
  -r    Upload directories recursively.
  -targetDir string
        Upload files or folders into this directory.  If flag is omitted,
        all data will be uploaded in the user's base directory.

    [file(s)|folder(s)]
        All flagless arguments will be used as file or directory names
        to upload.  Directories will be skipped if '-r' is not provided.
```