### PR TITLE
Fallback to .sda-cli-session if no config is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,13 +160,14 @@ where `urls_file` as described above.
 
 The uploaded files can be listed using the `list` parameter. This feature returns all the files in the user's bucket recursively and can be executed using:
 ```bash
-./sda-cli list -config <configuration_file>
+./sda-cli list [-config <configuration_file>]
 ```
  It also allows for requesting files/filepaths with a specified prefix using:
  ```bash
-./sda-cli list -config <configuration_file> <prefix>
+./sda-cli list [-config <configuration_file>] <prefix>
 ```
 This command will return any file/path starting with the defined `<prefix>`.
+If no config is given by the user, the tool will look for a previous login from the user.
 
 ## Download
 

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -275,6 +275,19 @@ func LoadConfigFile(path string) (*Config, error) {
 	return config, nil
 }
 
+// GetAuth calls LoadConfig if we have a config file, otherwise try to load .sda-cli-session
+func GetAuth(path string) (*Config, error) {
+
+	if path != "" {
+		return LoadConfigFile(path)
+	}
+	if FileExists(".sda-cli-session") {
+		return LoadConfigFile(".sda-cli-session")
+	}
+
+	return nil, errors.New("failed to read the configuration file")
+}
+
 // CheckTokenExpiration is used to determine whether the token is expiring in less than a day
 func CheckTokenExpiration(accessToken string) (bool, error) {
 

--- a/list/list.go
+++ b/list/list.go
@@ -17,12 +17,13 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help list` command
 var Usage = `
-USAGE: %s list -config <s3config-file> [prefix]
+USAGE: %s list [-config <s3config-file>] [prefix]
 
 list:
     Lists recursively all files under the user's folder in the Sensitive
     Data Archive (SDA).  If the [prefix] parameter is used, only the
-    files under the specified path will be returned.
+    files under the specified path will be returned. If no config is
+	specified, the tool will look for a previous session.
 `
 
 // ArgHelp is the suffix text that will be displayed after the argument list in
@@ -53,13 +54,8 @@ func List(args []string) error {
 		prefix = Args.Args()[0]
 	}
 
-	// Check that the s3 configuration file path exists
-	if *configPath == "" {
-		return errors.New("failed to find an s3 configuration file for listing data")
-	}
-
-	// Get the configuration in the struct
-	config, err := helpers.LoadConfigFile(*configPath)
+	// // Get the configuration file or the .sda-cli-session
+	config, err := helpers.GetAuth(*configPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config file, reason: %v", err)
 	}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -39,7 +39,7 @@ func (suite *TestSuite) TestNoConfig() {
 	os.Args = []string{"list", "-config", ""}
 
 	err := List(os.Args)
-	assert.EqualError(suite.T(), err, "failed to find an s3 configuration file for listing data")
+	assert.EqualError(suite.T(), err, "failed to load config file, reason: failed to read the configuration file")
 }
 
 func (suite *TestSuite) TestTooManyArgs() {

--- a/main.go
+++ b/main.go
@@ -113,6 +113,12 @@ func ParseArgs() (string, []string) {
 		Help(subcommand)
 	}
 
+	// list command can have no arguments since it can use the config from login
+	// so we immediately return in that case
+	if command == "list" {
+		return command, os.Args
+	}
+
 	// If no arguments are provided to the subcommand, it's not gonna be valid,
 	// so we print the subcommand help
 	if len(os.Args) == 1 {

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -280,13 +280,8 @@ func Upload(args []string) error {
 		return errors.New(*targetDir + " is not a valid target directory")
 	}
 
-	// Check that we have an s3 configuration file
-	if *configPath == "" {
-		return errors.New("failed to find an s3 configuration file for uploading data")
-	}
-
-	// Get the configuration in the struct
-	config, err := helpers.LoadConfigFile(*configPath)
+	// Get the configuration file or the .sda-cli-session
+	config, err := helpers.GetAuth(*configPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently the login option of the cli creates the .sda-cli-session file which is identical to the config file.
The cli should try on list and upload - that require a config - fall back to look for the .sda-cli-session file to use if no config is provided.