### PR TITLE
#232: add version command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,8 @@ builds:
     ignore:
       - goarch: 386
       - goarch: arm
+    ldflags:
+      - -s -w -X main.Version={{ GORELEASER_CURRENT_TAG }}
 archives:
   - name_template: >-
       {{ .ProjectName }}_

--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ Given that the instructions in the [download section](#download) have been follo
 ```
 where `<keypair_name>.sec.pem` the private key created in the [relevant section](#create-keys) and `<file_to_decrypt>` one of the files downloaded following the instructions of the [download section](#download-file).
 
+## Version
+You can get the current version of the sda-cli by running:
+```bash
+./sda-cli version
+```
+
 # Developers' section
 This section contains the information required to install, modify and run the `sda-cli` tool.
 

--- a/list/list.go
+++ b/list/list.go
@@ -15,7 +15,7 @@ import (
 // Help text and command line flags.
 
 // Usage text that will be displayed as command line help text when using the
-// `help download` command
+// `help list` command
 var Usage = `
 USAGE: %s list -config <s3config-file> [prefix]
 

--- a/main.go
+++ b/main.go
@@ -81,14 +81,16 @@ func main() {
 func ParseArgs() (string, []string) {
 
 	// Print usage if no arguments are provided
-	if os.Args[1] == "version" || os.Args[1] == "-v" || os.Args[1] == "--ver" {
+	if len(os.Args) < 2 {
+		Help("help")
+	}
+
+	if os.Args[1] == "version" || os.Args[1] == "-v" || os.Args[1] == "--version" {
 		if len(os.Args) != 2 {
 			Help("version")
 		}
 
 		return "version", os.Args
-	} else if len(os.Args) < 2 {
-		Help("help")
 	}
 
 	// Extract `command` from arg 1, then remove it from the flag list.

--- a/main.go
+++ b/main.go
@@ -13,8 +13,11 @@ import (
 	"github.com/NBISweden/sda-cli/helpers"
 	"github.com/NBISweden/sda-cli/list"
 	"github.com/NBISweden/sda-cli/upload"
+	"github.com/NBISweden/sda-cli/version"
 	log "github.com/sirupsen/logrus"
 )
+
+var Version = "development"
 
 var Usage = `USAGE: %s <command> [command-args]
 
@@ -37,6 +40,7 @@ var Commands = map[string]commandInfo{
 	"upload":      {upload.Args, upload.Usage, upload.ArgHelp},
 	"datasetsize": {datasetsize.Args, datasetsize.Usage, datasetsize.ArgHelp},
 	"list":        {list.Args, list.Usage, list.ArgHelp},
+	"version":     {version.Args, version.Usage, version.ArgHelp},
 }
 
 // Main does argument parsing, then delegates to one of the sub modules
@@ -62,6 +66,8 @@ func main() {
 		err = datasetsize.DatasetSize(args)
 	case "list":
 		err = list.List(args)
+	case "version":
+		err = version.Version(Version)
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command: %s", command)
 	}
@@ -75,7 +81,13 @@ func main() {
 func ParseArgs() (string, []string) {
 
 	// Print usage if no arguments are provided
-	if len(os.Args) < 2 {
+	if os.Args[1] == "version" || os.Args[1] == "-v" || os.Args[1] == "--ver" {
+		if len(os.Args) != 2 {
+			Help("version")
+		}
+
+		return "version", os.Args
+	} else if len(os.Args) < 2 {
 		Help("help")
 	}
 

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -23,7 +23,7 @@ import (
 // Help text and command line flags.
 
 // Usage text that will be displayed as command line help text when using the
-// `help download` command
+// `help upload` command
 var Usage = `
 USAGE: %s upload -config <s3config-file> (--encrypt-with-key <public-key-file>) (--force-overwrite) (--force-unencrypted) (-r) [file(s) | folder(s)] (-targetDir <upload-directory>)
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,37 @@
+package version
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+)
+
+// Help text and command line flags.
+
+// Usage text that will be displayed as command line help text when using the
+// `help version` command
+var Usage = `
+USAGE: %s version
+
+version:
+    Returns the version of the sda-cli tool.
+`
+
+// ArgHelp is the suffix text that will be displayed after the argument list in
+// the module help
+var ArgHelp = `
+    version does not take any arguments`
+
+// Args is a flagset that needs to be exported so that it can be written to the
+// main program help
+var Args = flag.NewFlagSet("version", flag.ExitOnError)
+
+// Returns the version of the sda-cli tool.
+func Version(ver string) error {
+	if len(Args.Args()) > 0 {
+		return errors.New("version does not take any arguments")
+	}
+	fmt.Println("sda-cli version: ", ver)
+
+	return nil
+}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,24 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type VersionTests struct {
+	suite.Suite
+}
+
+func TestVersionTestSuite(t *testing.T) {
+	suite.Run(t, new(VersionTests))
+}
+
+func (suite *VersionTests) TestGetVersion() {
+
+	// get version
+	err := Version("development")
+	assert.NoError(suite.T(), err)
+
+}


### PR DESCRIPTION
Added the command version that returns the current version of the cli.
The default version is defined in main and is equal to `development`.
An ldflag has been added to the golreleaser config that sets the GORELEASER_CURRENT_TAG to that variable in main.
It then gets picked up in the version implementation and is returned to the user.
Some modifications to the parsing of the arguments were needed because of the special case of version command having only two arguments.
closes: #232 