### PR TITLE
#240: Use login pub key

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ wget https://raw.githubusercontent.com/NBISweden/EGA-SE-user-docs/main/crypt4gh_
 
 Now that the public key is downloaded, the file(s) can be encrypted using the binary file created in the first step of this guide. To encrypt a specific file, use the following command:
 ```bash
-./sda-cli encrypt -key <public_key> <file_to_encrypt>
+./sda-cli encrypt [-key <public_key>] <file_to_encrypt>
 ```
 where `<public_key>` the key downloaded in the previous step. The tool also allows for encrypting multiple files at once, by listing them separated with space like:
 ```bash
 ./sda-cli encrypt -key <public_key> <file_1_to_encrypt> <file_2_to_encrypt> <file_3_to_encrypt>
 ```
 This command comes with the `-continue` option, which will continue encrypting files, even if one of them fails. To enable this feature, the command should be executed with the `-continue=true` option.
+If no public key is provided, the tool will look for it from a previous login session.
 
 ### Encrypt file(s) with multiple keys
 

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -75,9 +75,14 @@ func Encrypt(args []string) error {
 		return err
 	}
 
-	// Exit if public key is not provided
+	// no key provided, check for one in the session file
 	if len(publicKeyFileList) == 0 {
-		return fmt.Errorf("public key not provided")
+
+		sesKey, err := helpers.GetPublicKey()
+		if err != nil {
+			return fmt.Errorf("public key not provided, details: %v", err)
+		}
+		publicKeyFileList = append(publicKeyFileList, sesKey)
 	}
 
 	// Each filename is first read into a helper struct (sliced for combatibility with checkFiles)

--- a/encrypt/encrypt_test.go
+++ b/encrypt/encrypt_test.go
@@ -216,7 +216,7 @@ func (suite *EncryptTests) TestEncryptFunction() {
 	// pub key not given
 	os.Args = []string{"encrypt", suite.fileOk.Name()}
 	err := Encrypt(os.Args)
-	assert.EqualError(suite.T(), err, "public key not provided")
+	assert.EqualError(suite.T(), err, "public key not provided, details: configuration file (.sda-cli-session) not found")
 
 	// no such pub key file
 	msg := "open somekey: no such file or directory"

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/golang-jwt/jwt"
 	"github.com/manifoldco/promptui"
+	"github.com/neicnordic/crypt4gh/keys"
 	log "github.com/sirupsen/logrus"
 	"github.com/vbauerster/mpb/v8"
 	"golang.org/x/exp/slices"
@@ -227,6 +228,7 @@ type Config struct {
 	UseHTTPS             bool   `ini:"use_https"`
 	SocketTimeout        int    `ini:"socket_timeout"`
 	HumanReadableSizes   bool   `ini:"human_readable_sizes"`
+	PublicKey            string `ini:"public_key"`
 }
 
 // LoadConfigFile loads ini configuration file to the Config struct
@@ -273,6 +275,63 @@ func LoadConfigFile(path string) (*Config, error) {
 	}
 
 	return config, nil
+}
+
+// GetAuth calls LoadConfig if we have a config file, otherwise try to load .sda-cli-session
+func GetAuth(path string) (*Config, error) {
+
+	if path != "" {
+		return LoadConfigFile(path)
+	}
+	if FileExists(".sda-cli-session") {
+		return LoadConfigFile(".sda-cli-session")
+	}
+
+	return nil, errors.New("failed to read the configuration file")
+}
+
+func GetPublicKey() (string, error) {
+	// Check if the ".sda-cli-session" file exists
+	if !FileExists(".sda-cli-session") {
+		return "", errors.New("configuration file (.sda-cli-session) not found")
+	}
+
+	// Load the configuration file
+	config, err := LoadConfigFile(".sda-cli-session")
+	if err != nil {
+		return "", fmt.Errorf("failed to load configuration file: %w", err)
+	}
+
+	// Check if the PublicKey field is present in the config
+	if config.PublicKey == "" {
+		return "", errors.New("public key not found in the configuration")
+	}
+
+	// Create a fixed-size array to hold the public key data
+	var publicKeyData [32]byte
+	b := []byte(config.PublicKey)
+	copy(publicKeyData[:], b)
+
+	// Open or create a file named "key-from-oidc.pub.pem" in write-only mode with file permissions 0600
+	pubFile, err := os.OpenFile(filepath.Clean("key-from-oidc.pub.pem"), os.O_WRONLY|os.O_CREATE, 0600)
+	if err != nil {
+		return "", fmt.Errorf("failed to open or create the public key file: %w", err)
+	}
+	defer func() {
+		// Close the file and log any error that may occur
+		if cerr := pubFile.Close(); cerr != nil {
+			log.Errorf("Error closing file: %s\n", cerr)
+		}
+	}()
+
+	// Write the publicKeyData array to the "key-from-oidc.pub.pem" file in Crypt4GHX25519 public key format
+	err = keys.WriteCrypt4GHX25519PublicKey(pubFile, publicKeyData)
+	if err != nil {
+		return "", fmt.Errorf("failed to write the public key data: %w", err)
+	}
+
+	// If everything is successful, return the name of the generated public key file
+	return "key-from-oidc.pub.pem", nil
 }
 
 // CheckTokenExpiration is used to determine whether the token is expiring in less than a day

--- a/login/login.go
+++ b/login/login.go
@@ -55,6 +55,7 @@ type S3Config struct {
 	UseHTTPS             bool   `ini:"use_https"`
 	SocketTimeout        int    `ini:"socket_timeout"`
 	HumanReadableSizes   bool   `ini:"human_readable_sizes"`
+	PublicKey            string `ini:"public_key"`
 }
 
 type OIDCWellKnown struct {
@@ -93,6 +94,7 @@ type DeviceLogin struct {
 	BaseURL         string
 	ClientID        string
 	S3Target        string
+	PublicKey       string
 	PollingInterval int
 	LoginResult     *Result
 	UserInfo        *UserInfo
@@ -188,7 +190,7 @@ func NewDeviceLogin(args []string) (DeviceLogin, error) {
 		return DeviceLogin{}, errors.New("failed to get auth Info")
 	}
 
-	return DeviceLogin{BaseURL: info.OidcURI, ClientID: info.ClientID, PollingInterval: 2, S3Target: info.InboxURI}, nil
+	return DeviceLogin{BaseURL: info.OidcURI, ClientID: info.ClientID, PollingInterval: 2, S3Target: info.InboxURI, PublicKey: info.PublicKey}, nil
 }
 
 // open opens the specified URL in the default browser of the user.
@@ -251,7 +253,7 @@ func (login *DeviceLogin) Login() error {
 	return err
 }
 
-// S3Config() returns an
+// S3Config() returns a new `S3Config` with the values from the `DeviceLogin`
 func (login *DeviceLogin) GetS3Config() (*S3Config, error) {
 	if login.LoginResult.AccessToken == "" {
 
@@ -264,6 +266,7 @@ func (login *DeviceLogin) GetS3Config() (*S3Config, error) {
 		AccessToken:          login.LoginResult.AccessToken,
 		HostBucket:           login.S3Target,
 		HostBase:             login.S3Target,
+		PublicKey:            login.PublicKey,
 		MultipartChunkSizeMb: 512,
 		GuessMimeType:        false,
 		Encoding:             "UTF-8",


### PR DESCRIPTION
Encrypt reads all the keys that the key arguments from the user and then reads the session file to get the public key entry.
Then calls a func in helpers that creates a file "key-from-oidc.pub.pem" in cli root dir that contains that public key from login.
Last, it uses that key to encrypt instead of failing.
closes: #240 