### PR TITLE
Fix/225 help exit code

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,7 +93,8 @@ func ParseArgs() (string, []string) {
 		os.Exit(1)
 	}
 
-	if os.Args[1] == "version" || os.Args[1] == "-v" || os.Args[1] == "--version" {
+	switch os.Args[1] {
+	case "version", "-v", "-version", "--version":
 		if len(os.Args) != 2 {
 			Help("version")
 			os.Exit(1)
@@ -111,7 +112,7 @@ func ParseArgs() (string, []string) {
 	// exit.  Let the Help function whether to exit with status zero
 	// or one depending on whether the subcommand is valid or not.
 	switch command {
-	case "-h", "help", "-help", "--help":
+	case "help", "-h", "-help", "--help":
 		var subcommand string
 		if len(os.Args) > 1 {
 			subcommand = os.Args[1]

--- a/main.go
+++ b/main.go
@@ -88,14 +88,14 @@ func ParseArgs() (string, []string) {
 	// Print usage if no arguments are provided.
 	// Terminate with non-zero exit status.
 	if len(os.Args) < 2 {
-		Help("help")
+		_ = Help("help")
 		os.Exit(1)
 	}
 
 	switch os.Args[1] {
 	case "version", "-v", "-version", "--version":
 		if len(os.Args) != 2 {
-			Help("version")
+			_ = Help("version")
 			os.Exit(1)
 		}
 
@@ -137,7 +137,7 @@ func ParseArgs() (string, []string) {
 	// going to be valid.  Print the subcommand help and exit with a
 	// non-zero exit status.
 	if len(os.Args) == 1 {
-		Help(command)
+		_ = Help(command)
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -85,7 +85,6 @@ func main() {
 // Parses the command line arguments into a command, and keep the rest
 // of the arguments for the subcommand.
 func ParseArgs() (string, []string) {
-
 	// Print usage if no arguments are provided.
 	// Terminate with non-zero exit status.
 	if len(os.Args) < 2 {
@@ -114,6 +113,7 @@ func ParseArgs() (string, []string) {
 	switch command {
 	case "help", "-h", "-help", "--help":
 		var subcommand string
+
 		if len(os.Args) > 1 {
 			subcommand = os.Args[1]
 		} else {
@@ -148,19 +148,17 @@ func ParseArgs() (string, []string) {
 // depending on the command argument.  Returns an error if the command
 // is not recognized.
 func Help(command string) error {
-
 	info, isLegal := Commands[command]
 	if !isLegal {
 		if command != "help" {
 			fmt.Fprintf(os.Stderr, "Unknown command: %s\n", command)
 		}
+
 		// print main help
 		fmt.Fprintf(os.Stderr, Usage, os.Args[0])
 		fmt.Fprintln(os.Stderr, "The tool can help with these actions:")
 		for _, info := range Commands {
-
 			subcommandUsage := helpers.FormatSubcommandUsage(info.usage)
-
 			fmt.Fprint(os.Stderr, subcommandUsage)
 		}
 		fmt.Fprintf(os.Stderr,

--- a/main.go
+++ b/main.go
@@ -82,11 +82,12 @@ func main() {
 	}
 }
 
-// Parses the command line arguments into a command, and keep the rest of the
-// arguments for the subcommand
+// Parses the command line arguments into a command, and keep the rest
+// of the arguments for the subcommand.
 func ParseArgs() (string, []string) {
 
-	// Print usage if no arguments are provided
+	// Print usage if no arguments are provided.
+	// Terminate with non-zero exit status.
 	if len(os.Args) < 2 {
 		Help("help")
 		os.Exit(1)
@@ -101,11 +102,14 @@ func ParseArgs() (string, []string) {
 		return "version", os.Args
 	}
 
-	// Extract `command` from arg 1, then remove it from the flag list.
+	// Extract the command from the 1st argument, then remove it
+	// from list of arguments.
 	command := os.Args[1]
 	os.Args = append(os.Args[:1], os.Args[2:]...)
 
-	// If `command` is help-like, we print the help text and exit
+	// If the command is "help-like", we print the help text and
+	// exit.  Let the Help function whether to exit with status zero
+	// or one depending on whether the subcommand is valid or not.
 	switch command {
 	case "-h", "help", "-help", "--help":
 		var subcommand string
@@ -122,14 +126,15 @@ func ParseArgs() (string, []string) {
 		}
 	}
 
-	// list command can have no arguments since it can use the config from login
-	// so we immediately return in that case
+	// The "list" command can have no arguments since it can use the
+	// config from login so we immediately return in that case.
 	if command == "list" {
 		return command, os.Args
 	}
 
-	// If no arguments are provided to the subcommand, it's not gonna be valid,
-	// so we print the subcommand help
+	// If no arguments are provided to the subcommand, it's not
+	// going to be valid.  Print the subcommand help and exit with a
+	// non-zero exit status.
 	if len(os.Args) == 1 {
 		Help(command)
 		os.Exit(1)


### PR DESCRIPTION
This closes #225 

The PR moves the actual `os.Exit()` call out of the `Help()` function, which allows the caller to exit with either a zero or non-zero exit status, depending on the circumstances.