### PR TITLE
Encrypt fetches pub key from auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ You can login to download the configuration file needed for some of the the tool
 ```bash
 ./sda-cli login <login_target>
 ```
-where `login_target` is the URL can be the login endpoint for Big Picture (https://login.bp.nbis.se/), Federated EGA (https://login.fega.nbis.se/) or Genomic Data Infrastructure (https://login.gdi.nbis.se/)
+where `login_target` is the URL to the `sda-auth` service from the [sensitive-data-archive](https://github.com/neicnordic/sensitive-data-archive/) project.
 
 This will open a link for the user where they can go and log in.
 After the login is complete, a configuration file will be created in the tool's directory with the name of `.sda-cli-session`

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ You can login to download the configuration file needed for some of the the tool
 ```bash
 ./sda-cli login <login_target>
 ```
-where `login_target` is the URL can be the login endpoint for Big Picture (https://login.bp.nbis.se/), Federated EGA (https://login.test.fega.nbis.se/) or Genomic Data Infrastructure (https://login.gdi.nbis.se/)
+where `login_target` is the URL can be the login endpoint for Big Picture (https://login.bp.nbis.se/), Federated EGA (https://login.fega.nbis.se/) or Genomic Data Infrastructure (https://login.gdi.nbis.se/)
 
 This will open a link for the user where they can go and log in.
 After the login is complete, a configuration file will be created in the tool's directory with the name of `.sda-cli-session`

--- a/encrypt/encrypt_test.go
+++ b/encrypt/encrypt_test.go
@@ -210,7 +210,7 @@ func (suite *EncryptTests) TestEncryptFunction() {
 	// pub key not given
 	os.Args = []string{"encrypt", suite.fileOk.Name()}
 	err := Encrypt(os.Args)
-	assert.EqualError(suite.T(), err, "public key not provided or configuration file (.sda-cli-session) not found")
+	assert.EqualError(suite.T(), err, "no public key could be obtained")
 
 	// no such pub key file
 	msg := "open somekey: no such file or directory"

--- a/encrypt/encrypt_test.go
+++ b/encrypt/encrypt_test.go
@@ -210,7 +210,7 @@ func (suite *EncryptTests) TestEncryptFunction() {
 	// pub key not given
 	os.Args = []string{"encrypt", suite.fileOk.Name()}
 	err := Encrypt(os.Args)
-	assert.EqualError(suite.T(), err, "no public key could be obtained")
+	assert.EqualError(suite.T(), err, "configuration file (.sda-cli-session) not found")
 
 	// no such pub key file
 	msg := "open somekey: no such file or directory"

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -299,11 +299,9 @@ func GetPublicKeyFromSession() (string, error) {
 		return "", errors.New("configuration file (.sda-cli-session) not found")
 	}
 
-	if FileExists(".sda-cli-session") {
-		file, err := os.Open(".sda-cli-session")
-		if err != nil {
-			fmt.Println("could not read file:", file)
-		}
+	_, err := os.Open(".sda-cli-session")
+	if err != nil {
+		return "", err
 	}
 
 	// Load the configuration file
@@ -319,7 +317,7 @@ func GetPublicKeyFromSession() (string, error) {
 
 	pubFile, err := CreatePubFile(config.PublicKey, "key-from-oidc.pub.pem")
 	if err != nil {
-		return "", fmt.Errorf("failed to create public key file: %w", err)
+		return "", err
 	}
 
 	return pubFile, nil
@@ -328,13 +326,12 @@ func GetPublicKeyFromSession() (string, error) {
 
 // Create public key file
 func CreatePubFile(publicKey string, filename string) (string, error) {
-
 	// Create a fixed-size array to hold the public key data
 	var publicKeyData [32]byte
 	b := []byte(publicKey)
 	copy(publicKeyData[:], b)
 
-	// Open or create a file named "key-from-oidc.pub.pem" in write-only mode with file permissions 0600
+	// Open or create a file in write-only mode with file permissions 0600
 	pubFile, err := os.OpenFile(filepath.Clean(filename), os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		return "", fmt.Errorf("failed to open or create the public key file: %w", err)
@@ -345,7 +342,6 @@ func CreatePubFile(publicKey string, filename string) (string, error) {
 			log.Errorf("Error closing file: %s\n", cerr)
 		}
 	}()
-
 	// Write the publicKeyData array to the "key-from-oidc.pub.pem" file in Crypt4GHX25519 public key format
 	err = keys.WriteCrypt4GHX25519PublicKey(pubFile, publicKeyData)
 	if err != nil {

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -361,7 +361,7 @@ encrypt = False
 		log.Printf("failed to write temp config file, %v", err)
 	}
 
-	_, err = GetPublicKey()
+	_, err = GetPublicKeyFromSession()
 	assert.EqualError(suite.T(), err, "public key not found in the configuration")
 }
 
@@ -396,7 +396,7 @@ public_key = 27be42445fd9e39c9be39e6b36a55e61e3801fc845f63781a813d3fe9977e17a
 		log.Printf("failed to write temp config file, %v", err)
 	}
 
-	_, err = GetPublicKey()
+	_, err = GetPublicKeyFromSession()
 	assert.NoError(suite.T(), err)
 
 	if assert.FileExists(suite.T(), "key-from-oidc.pub.pem") {

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -365,7 +365,7 @@ encrypt = False
 	assert.EqualError(suite.T(), err, "public key not found in the configuration")
 }
 
-func (suite *HelperTests) TestGetPublicKey() {
+func (suite *HelperTests) TestGetPublicKeyFromSession() {
 
 	var confFile = `
 access_token = someToken
@@ -414,4 +414,19 @@ func (suite *HelperTests) TestInvalidCharacters() {
 		assert.Error(suite.T(), err)
 		assert.Equal(suite.T(), fmt.Sprintf("filepath %v contains disallowed characters: %+v", testfilepath, badchar), err.Error())
 	}
+}
+
+func (suite *HelperTests) TestCreatePubFile() {
+	var pubKeyContent = `339eb2a458fec5e23aa8b57cfcb35f10e7389025816e44d4234f814ed2aeed3f`
+	var expectedPubKey = `-----BEGIN CRYPT4GH PUBLIC KEY-----
+MzM5ZWIyYTQ1OGZlYzVlMjNhYThiNTdjZmNiMzVmMTA=
+-----END CRYPT4GH PUBLIC KEY-----
+`
+	_, err := CreatePubFile(pubKeyContent, os.TempDir()+"/test_public_file.pub.pem")
+	assert.NoError(suite.T(), err)
+
+	pubFile, _ := os.ReadFile(os.TempDir() + "/test_public_file.pub.pem")
+	s := string(pubFile)
+	assert.Equal(suite.T(), expectedPubKey, s)
+	defer os.Remove(os.TempDir() + "/test_public_file.pub.pem")
 }

--- a/login/login.go
+++ b/login/login.go
@@ -32,10 +32,7 @@ login:
 // the module help
 var ArgHelp = `
     [login-target]
-        The login target can be one of the following: 
-			https://login.bp.nbis.se/
-			https://login.test.fega.nbis.se/
-			https://login.gdi.nbis.se/`
+        The login target is the base URL of the service.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help
@@ -168,7 +165,7 @@ func NewLogin(args []string) error {
 	}
 	err = deviceLogin.Login()
 	if err != nil {
-		return fmt.Errorf("Login failed")
+		return err
 	}
 	fmt.Printf("Logged in as %v\n", deviceLogin.UserInfo.Name)
 

--- a/main.go
+++ b/main.go
@@ -122,9 +122,9 @@ func ParseArgs() (string, []string) {
 
 		if Help(subcommand) == nil {
 			os.Exit(0)
-		} else {
-			os.Exit(1)
 		}
+		os.Exit(1)
+
 	}
 
 	// The "list" command can have no arguments since it can use the


### PR DESCRIPTION
closes #264 
Change encrypt module to fetch the public key from auth's endpoint info. Encrypt will now try to find a public key in the following order from:
- provided as an argument
- if `target` was provided, fetch it
- lookup in the .sda-cli-session from a previous login
