### PR TITLE
Disallow invalid characters in filepaths

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -395,4 +396,15 @@ func ListFiles(config Config, prefix string) (result *s3.ListObjectsV2Output, er
 	}
 
 	return result, nil
+}
+
+// Check for invalid characters
+func CheckValidChars(filename string) error {
+	re := regexp.MustCompile(`[\\:\*\?"<>\|\x00-\x1F\x7F]`)
+	dissallowedChars := re.FindAllString(filename, -1)
+	if dissallowedChars != nil {
+		return fmt.Errorf("filepath %v contains disallowed characters: %+v", filename, strings.Join(dissallowedChars, ", "))
+	}
+
+	return nil
 }

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -377,3 +377,15 @@ public_key = 27be42445fd9e39c9be39e6b36a55e61e3801fc845f63781a813d3fe9977e17a
 		os.Remove("key-from-oidc.pub.pem")
 	}
 }
+
+func (suite *HelperTests) TestInvalidCharacters() {
+	// Test that file paths with invalid characters trigger errors
+	for _, badc := range "\x00\x7F\x1A:*?\\" {
+		badchar := string(badc)
+		testfilepath := "test" + badchar + "file"
+
+		err := CheckValidChars(testfilepath)
+		assert.Error(suite.T(), err)
+		assert.Equal(suite.T(), fmt.Sprintf("filepath %v contains disallowed characters: %+v", testfilepath, badchar), err.Error())
+	}
+}

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/NBISweden/sda-cli/encrypt"
@@ -74,10 +73,9 @@ func uploadFiles(files, outFiles []string, targetDir string, config *helpers.Con
 
 	// Loop through the list of file paths and check if their names are valid
 	for _, filename := range outFiles {
-		re := regexp.MustCompile(`[\\:\*\?"<>\|\x00-\x1F\x7F]`)
-		dissallowedChars := re.FindAllString(filename, -1)
-		if dissallowedChars != nil {
-			return fmt.Errorf("filepath %v contains disallowed characters: %+v", filename, strings.Join(dissallowedChars, ", "))
+		err := helpers.CheckValidChars(filename)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -261,14 +261,19 @@ func Upload(args []string) error {
 		return fmt.Errorf("failed parsing arguments, reason: %v", err)
 	}
 
-	// Check that specified target directory is valid, i.e. not a filepath or a flag
-	info, err := os.Stat(*targetDir)
-
 	// Dereference the pointer to a string
 	var targetDirString string
 	if targetDir != nil {
 		targetDirString = *targetDir
 	}
+
+	err = helpers.CheckValidChars(filepath.ToSlash(targetDirString))
+	if err != nil {
+		return err
+	}
+
+	// Check that specified target directory is valid, i.e. not a filepath or a flag
+	info, err := os.Stat(*targetDir)
 
 	if (!os.IsNotExist(err) && !info.IsDir()) || (targetDirString != "" && targetDirString[0:1] == "-") {
 		return errors.New(*targetDir + " is not a valid target directory")

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -235,7 +235,7 @@ func createFilePaths(dirPath string) ([]string, []string, error) {
 			// Remove possible trailing "/" so that "path" and "path/" behave the same
 			dirPath = strings.TrimSuffix(dirPath, string(os.PathSeparator))
 			pathToTrim := strings.TrimSuffix(dirPath, filepath.Base(dirPath))
-			outPath := formatUploadFilePath(strings.TrimPrefix(path, pathToTrim))
+			outPath := filepath.ToSlash(strings.TrimPrefix(path, pathToTrim))
 			outFiles = append(outFiles, outPath)
 		}
 
@@ -247,20 +247,6 @@ func createFilePaths(dirPath string) ([]string, []string, error) {
 	}
 
 	return files, outFiles, nil
-}
-
-// formatUploadFilePath ensures that path separators are "/", and that special
-// characters are replaced with safe characters.
-func formatUploadFilePath(filePath string) string {
-
-	outPath := filepath.ToSlash(filePath)
-
-	for _, char := range []string{":", ";"} {
-		outPath = strings.ReplaceAll(outPath, char, "_")
-	}
-	log.Debugf("Converted filepath %v to %v", filePath, outPath)
-
-	return outPath
 }
 
 // Upload function uploads files to the s3 bucket. Input can be files or
@@ -338,7 +324,7 @@ func Upload(args []string) error {
 			outFiles = append(outFiles, upFilePaths...)
 		} else {
 			files = append(files, filePath)
-			outFiles = append(outFiles, formatUploadFilePath(filepath.Base(filePath)))
+			outFiles = append(outFiles, filepath.ToSlash(filepath.Base(filePath)))
 		}
 	}
 

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -269,7 +269,7 @@ func Upload(args []string) error {
 
 	err = helpers.CheckValidChars(filepath.ToSlash(targetDirString))
 	if err != nil {
-		return err
+		return errors.New(*targetDir + " is not a valid target directory")
 	}
 
 	// Check that specified target directory is valid, i.e. not a filepath or a flag

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/NBISweden/sda-cli/encrypt"
@@ -69,6 +70,15 @@ func uploadFiles(files, outFiles []string, targetDir string, config *helpers.Con
 	// check also here in case sth went wrong with input files
 	if len(files) == 0 {
 		return errors.New("no files to upload")
+	}
+
+	// Loop through the list of file paths and check if their names are valid
+	for _, filename := range outFiles {
+		re := regexp.MustCompile(`[\\:\*\?"<>\|\x00-\x1F\x7F]`)
+		dissallowedChars := re.FindAllString(filename, -1)
+		if dissallowedChars != nil {
+			return fmt.Errorf("filepath %v contains disallowed characters: %+v", filename, strings.Join(dissallowedChars, ", "))
+		}
 	}
 
 	// Loop through the list of files and check if they are encrypted

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -427,7 +427,7 @@ func (suite *TestSuite) TestRecursiveToDifferentTarget() {
 func (suite *TestSuite) TestUploadInvalidCharacters() {
 	// Filenames with :\?* can not be created on windows
 	if runtime.GOOS == "windows" {
-		return
+		suite.T().Skip("Skipping. Cannot create filenames with invalid characters on windows")
 	}
 
 	// Create a fake s3 backend

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -135,21 +135,6 @@ func (suite *TestSuite) TestcreateFilePaths() {
 	assert.ErrorContains(suite.T(), err, msg)
 }
 
-func (suite *TestSuite) TestFormatUploadFilePath() {
-
-	unixPath := "a/b/c.c4gh"
-	testPath := filepath.Join("a", "b", "c.c4gh")
-	uploadPath := formatUploadFilePath(testPath)
-
-	assert.Equal(suite.T(), unixPath, uploadPath)
-
-	weirdPath := "a/b:/c;.c4gh"
-	goodPath := "a/b_/c_.c4gh"
-	formattedPath := formatUploadFilePath(weirdPath)
-
-	assert.Equal(suite.T(), goodPath, formattedPath)
-}
-
 func (suite *TestSuite) TestFunctionality() {
 
 	// Create a fake s3 backend

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -462,7 +462,7 @@ func (suite *TestSuite) TestUploadInvalidCharacters() {
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		log.Printf("failed to write temp config file, %v", err)
+		log.Panic(err)
 	}
 
 	// Create temp dir with file
@@ -483,7 +483,7 @@ func (suite *TestSuite) TestUploadInvalidCharacters() {
 		}
 		err = os.WriteFile(testfile.Name(), []byte("content"), 0600)
 		if err != nil {
-			log.Printf("failed to write temp file, %v", err)
+			log.Panic(err)
 		}
 		defer os.Remove(testfile.Name())
 

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -493,7 +493,7 @@ func (suite *TestSuite) TestUploadInvalidCharacters() {
 		os.Args = []string{"upload", "--force-unencrypted", "-config", configPath.Name(), "-targetDir", targetDir, "-r", testfile.Name()}
 		err = Upload(os.Args)
 		assert.Error(suite.T(), err)
-		assert.Equal(suite.T(), fmt.Sprintf("filepath %v contains disallowed characters: %+v", targetDir, badchar), err.Error())
+		assert.Equal(suite.T(), targetDir+" is not a valid target directory", err.Error())
 	}
 
 	// Filenames with :\?* can not be created on windows, skip the following tests


### PR DESCRIPTION
This PR closes #185 .

Adds a check to see if there are invalid characters in any file path and reports an error if there is:
```sh
go run main.go upload -config ../sda-s3proxy/dev_utils/proxyS3 file\?path

Error: filepath file?path contains disallowed characters: ?
exit status 1
```