### PR TITLE
replace individual names with team name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,7 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     reviewers:
-      - dbampalikis
-      - jbygdell
-      - norling
-      - aaperis
-      - kostas-kou
+      - "NBISweden/giant-sloth"
   - package-ecosystem: docker
     directory: ./
     schedule:
@@ -21,8 +17,4 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     reviewers:
-      - dbampalikis
-      - jbygdell
-      - norling
-      - aaperis
-      - kostas-kou
+      - "NBISweden/giant-sloth"


### PR DESCRIPTION
Dependabot malfunctions because Martin is not a collaborator (sadly). See e.g. https://github.com/NBISweden/sda-cli/pull/300#issuecomment-1839436473 .