### PR TITLE
add issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+
+---
+
+**Describe the bug**
+
+**Steps to reproduce**
+
+**Expected behavior**
+- [ ] <!-- Issue specific criteria -->
+- [ ] Tests verifying the fix are added
+
+**Additional context**
+
+**Estimation of size**: small/medium/big
+
+**Estimation of priority**: low/medium/high

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Please describe the feature**
+As a [type of user], I want [an action] so that [a benefit/a value].
+
+**Acceptance criteria**
+- [ ] <!--Placeholder for issue specific criterion-->
+- [ ] Tests verifying the changes are added
+
+**Additional context**
+
+**Estimation of size**: small/medium/big
+
+**Estimation of priority**: low/medium/high

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+**Related issue(s) and PR(s)**  
+This PR closes [issue number].
+
+
+**Description**
+
+
+**How to test**


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR addresses neicnordic/sensitive-data-archive#417.


**Description**
The PR adds one template for pull requests, one for bug reports and one for feature requests.

The templates are kept quite minimal. The goal is that they should provide structure and serve as reminders to supply relevant information.

**How to test**
See the added files.

**Further comments**
Before the connected issue can be closed, the templates should be added to all relevant repos. My guess of which repos that are relevant:

NBIS:
 - BigPicture-Deployment
 - bp-sweden-web
 - cytomine-bp-helm
 - EGA-SE-user-docs
 - fega-sweden-web
 - gdi.nbis.se
 - htsget-refserver
 - LocalEGA-SE-Deployment
 - rems-operation
 - sda-cli
 - sda-metadata-reviewer
 - sda-services-backup
 - sda-uppmax-integration
 - sda-web-portal

neicnordic
  - sensitive-data-archive
  - sda-download

GenomicDataInfrastructure
  - starter-kit-htsget
  - starter-kit-se-deployment-notes
  - starter-kit-storage-and-inferfaces

Does the list seem to be correct?
