### PR TITLE
Fix goreleaser so we get automatic builds back

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,7 @@ builds:
       - goarch: 386
       - goarch: arm
     ldflags:
-      - -s -w -X main.Version={{ GORELEASER_CURRENT_TAG }}
+      - -s -w -X main.Version={{ .Tag }}
 archives:
   - name_template: >-
       {{ .ProjectName }}_


### PR DESCRIPTION
This should make the goreleaser workflow function again.

Goreleaser seems to have both `.Version` supposedly meaning the version derived, but without initial `v` in our case, and `.Tag` meaning the git tag (see https://goreleaser.com/customization/templates/) for more information). For consistency, I think `.Tag` is what we want, but could to with `.Version` as well if preferred.

Closes #365 .
