### PR TITLE
update to go 1.22

### DIFF
--- a/.github/workflows/golint.yaml
+++ b/.github/workflows/golint.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.21"]
+        go-version: ["1.22"]
     steps:
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: ["1.21"]
+        go-version: ["1.22"]
         os:
           - ubuntu-latest
           - windows-latest

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ You can get the current version of the sda-cli by running:
 This section contains the information required to install, modify and run the `sda-cli` tool.
 
 ## Requirements
-The `sda-cli` is written in golang. In order to be able to modify, build and run the tool, golang (>= 1.21) needs to be installed. The instructions for installing `go` can be found [here](https://go.dev/doc/install).
+The `sda-cli` is written in golang. In order to be able to modify, build and run the tool, golang (>= 1.22) needs to be installed. The instructions for installing `go` can be found [here](https://go.dev/doc/install).
 
 ## Build tool
 To build the `sda-cli` tool run the following command from the root folder of the repository

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/NBISweden/sda-cli
 
-go 1.21
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go v1.53.5


### PR DESCRIPTION
New crypt4gh version requires go 1.22: #384 .