### PR TITLE
Help returns exit 0 code

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func ParseArgs() (string, []string) {
 	// Print usage if no arguments are provided.
 	if len(os.Args) < 2 {
 		_ = Help("help")
-		os.Exit(0)
+		os.Exit(1)
 	}
 
 	switch os.Args[1] {
@@ -138,7 +138,7 @@ func ParseArgs() (string, []string) {
 	// non-zero exit status.
 	if len(os.Args) == 1 {
 		_ = Help(command)
-		os.Exit(0)
+		os.Exit(1)
 	}
 
 	return command, os.Args

--- a/main.go
+++ b/main.go
@@ -86,17 +86,16 @@ func main() {
 // of the arguments for the subcommand.
 func ParseArgs() (string, []string) {
 	// Print usage if no arguments are provided.
-	// Terminate with non-zero exit status.
 	if len(os.Args) < 2 {
 		_ = Help("help")
-		os.Exit(1)
+		os.Exit(0)
 	}
 
 	switch os.Args[1] {
 	case "version", "-v", "-version", "--version":
 		if len(os.Args) != 2 {
 			_ = Help("version")
-			os.Exit(1)
+			os.Exit(0)
 		}
 
 		return "version", os.Args
@@ -119,11 +118,12 @@ func ParseArgs() (string, []string) {
 		} else {
 			subcommand = "help"
 		}
-
-		if Help(subcommand) == nil {
-			os.Exit(0)
+		// If the subcommand is not recognized, we exit with status 1
+		err := Help(subcommand)
+		if err != nil {
+			os.Exit(1)
 		}
-		os.Exit(1)
+		os.Exit(0)
 
 	}
 
@@ -138,7 +138,7 @@ func ParseArgs() (string, []string) {
 	// non-zero exit status.
 	if len(os.Args) == 1 {
 		_ = Help(command)
-		os.Exit(1)
+		os.Exit(0)
 	}
 
 	return command, os.Args
@@ -162,10 +162,14 @@ func Help(command string) error {
 			fmt.Fprint(os.Stderr, subcommandUsage)
 		}
 		fmt.Fprintf(os.Stderr,
-			"Use '%s help <command>' to get help with subcommand flags.\n",
+			"use '%s help <command>' to get help with subcommand flags.\n",
 			os.Args[0])
 
-		return fmt.Errorf("Unknown command: %s", command)
+		if command == "help" {
+			return nil
+		}
+
+		return fmt.Errorf("unknown command: %s", command)
 	}
 
 	// print subcommand help


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #313 


**Description**
Currently sda-cli does not return the correct exit code when we run help or -h (exit 1)
It should return exit code 0 except the case of asking for a wrong subcommand.

**How to test**
Run:
```
./sda-cli help
./sda-cli -h
./sda-cli help list
./sda-cli help inexistent_command
```
followed each time by:
```
echo $?
```
to get the exit code of the previous command.