### PR TITLE
Feature/recursive download

### DIFF
--- a/.github/integration/tests/tests.sh
+++ b/.github/integration/tests/tests.sh
@@ -389,4 +389,20 @@ fi
 
 rm -r test-download
 
+# Download recursively a folder
+echo "Downloading content of folder"
+./sda-cli sda-download -config testing/s3cmd-download.conf -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-folder --recursive main/subfolder2
+
+folderpaths="download-folder/main/subfolder2/dummy_data2 download-folder/main/subfolder2/random/dummy_data3"
+
+# Check if the content of the folder has been downloaded
+for folderpath in $folderpaths; do
+    if [ ! -f "$folderpath" ]; then
+        echo "Content of folder $folderpath is missing"
+        exit 1
+    fi
+done
+
+rm -r download-folder 
+
 echo "Integration test finished successfully"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-SDA-CLI
-=======
+# SDA-CLI
 
 This is the Sensitive Data Archive (SDA) Command Line Interface (sda-cli). This
 tool was created to unify and simplify the tools needed to perform the most
@@ -11,6 +10,7 @@ and to download and decrypt with retrieving data from the archive.
 It is recommended to use precompiled executables for `sda-cli` which can be found at https://github.com/NBISweden/sda-cli/releases
 
 To get help on the usage of the tool, please use the following command
+
 ```bash
 ./sda-cli help
 ```
@@ -28,10 +28,13 @@ The files stored in the SDA/BP archive are encrypted using the [crypt4gh standar
 ### Download the crypt4gh public key
 
 The files that are uploaded to the SDA/BP services, need to be encrypted with the correct public key. Depending on the service you want to use, this key can be downloaded using this command **if you are uploading to the SDA**:
+
 ```bash
 wget https://raw.githubusercontent.com/NBISweden/EGA-SE-user-docs/main/crypt4gh_key.pub
 ```
+
 or this command **if you are uploading to Big Picture**:
+
 ```bash
 wget https://raw.githubusercontent.com/NBISweden/EGA-SE-user-docs/main/crypt4gh_bp_key.pub
 ```
@@ -39,27 +42,36 @@ wget https://raw.githubusercontent.com/NBISweden/EGA-SE-user-docs/main/crypt4gh_
 ### Encrypt file(s)
 
 Now that the public key is downloaded, the file(s) can be encrypted using the binary file created in the first step of this guide. To encrypt a specific file, use the following command:
+
 ```bash
 ./sda-cli encrypt [-key <public_key>] <file_to_encrypt>
 ```
+
 where `<public_key>` the key downloaded in the previous step. The tool also allows for encrypting multiple files at once, by listing them separated with space like:
+
 ```bash
 ./sda-cli encrypt -key <public_key> <file_1_to_encrypt> <file_2_to_encrypt> <file_3_to_encrypt>
 ```
+
 This command comes with the `-continue` option, which will continue encrypting files, even if one of them fails. To enable this feature, the command should be executed with the `-continue=true` option.
 If no public key is provided, the tool will look for it from a previous login session.
 
 ### Encrypt file(s) with multiple keys
 
 To encrypt files with more than one public keys, repeatedly use the `-key` flag, e.g.
+
 ```bash
 ./sda-cli encrypt -key <public_key1> -key <public_key2> <file_to_encrypt>
 ```
+
 will encrypt a file using two keys so that it can be decrypted with either of the corresponding private keys. Encryption with more than two keys is possible, as well. Another option is to provide as argument to `-key` a file with concatenated public keys generated e.g. from a command like
+
 ```bash
 cat <pub_key1> <pub_key2> > <concatenated_pub_keys>
 ```
+
 Passing a combination of the above arguments is allowed, as well:
+
 ```bash
 ./sda-cli encrypt -key <concatenated_public_keys> -key <public_key3> <file_to_encrypt>
 ```
@@ -67,7 +79,6 @@ Passing a combination of the above arguments is allowed, as well:
 **Note**: The `encrypt` command will create four files containing hashes (both md5 and sha256) for the encrypted and unencrypted files, respectively.
 
 **Developers' Notes:** The tool is creating a key pair when encrypting the files. This key pair is temporary for security reasons.
-
 
 ## Upload
 
@@ -77,7 +88,7 @@ Once your files are encrypted, they are ready to be submitted to the SDA/BP arch
 
 The configuration file can be downloaded by logging in with a Life Science RI account:
 
-* For BigPicture use https://login.bp.nbis.se/
+- For BigPicture use https://login.bp.nbis.se/
 
 Follow the dialogue to get authenticated and then click on `Download inbox s3cmd credentials` to download the configuration file named s3cmd.conf. The configuration file should be placed in the root folder of the repository.
 
@@ -86,60 +97,76 @@ Alternatively, you can download the configuration file using the [login command]
 ### Upload file(s)
 
 Now that the configuration file is downloaded, the file(s) can be uploaded to the archive using the binary file created in the first step of this guide. To upload a specific file, use the following command:
+
 ```bash
 ./sda-cli upload -config <configuration_file> <encrypted_file_to_upload>
 ```
+
 where `<configuration_file>` the file downloaded in the previous step and `<encrypted_file_to_upload>` a file encrypted in the earlier steps. The tool also allows for uploading multiple files at once, by listing them separated with space like:
+
 ```bash
 ./sda-cli upload -config <configuration_file> <encrypted_file_1_to_upload> <encrypted_file_2_to_upload>
 ```
+
 Note that the files will be uploaded in the base folder of the user.
 
 ### Upload folder(s)
 
 One can also upload entire directories recursively, i.e. including all contained files and folders while keeping the local folder structure. This can be achieved with the `-r` flag, e.g. running:
+
 ```bash
 ./sda-cli upload -config <configuration_file> -r <folder_to_upload>
 ```
+
 will upload `<folder_to_upload>` as is, i.e. with the same inner folder and file structure as the local one, to the archive.
 
 It is also possible to specify multiple directories and files for upload with the same command. For example,
+
 ```bash
 ./sda-cli upload -config <configuration_file> -r <encrypted_file_1_to_upload> <encrypted_file_2_to_upload> <folder_1_to_upload> <folder_2_to_upload>
 ```
+
 However, if `-r` is omitted in the above, any folders will be skipped during upload.
 
 ### Upload to a different path
 
 The user can specify a different path for uploading files/folders with the `-targetDir` flag followed by the name of the folder. For example, the command:
+
 ```bash
 ./sda-cli upload -config <configuration_file> -r <encrypted_file_1_to_upload> <folder_1_to_upload> -targetDir <upload_folder>
 ```
-will create `<upload_folder>` under the user's base folder with  contents `<upload_folder>/<encrypted_file_1_to_upload>` and `<upload_folder>/<folder_1_to_upload>`. Note that the given `<upload_folder>` may well be a folder path, e.g. `<folder1/folder2>`, and in this case `<encrypted_file_1_to_upload>` will be uploaded to `folder1/folder2/<encrypted_file_1_to_upload>`.
+
+will create `<upload_folder>` under the user's base folder with contents `<upload_folder>/<encrypted_file_1_to_upload>` and `<upload_folder>/<folder_1_to_upload>`. Note that the given `<upload_folder>` may well be a folder path, e.g. `<folder1/folder2>`, and in this case `<encrypted_file_1_to_upload>` will be uploaded to `folder1/folder2/<encrypted_file_1_to_upload>`.
 
 As a side note it is possible to include all the contents of a directory with `/.`, for example,
+
 ```bash
 ./sda-cli upload -config <configuration_file> -r <folder_to_upload>/. -targetDir <new_folder_name>
 ```
+
 will upload all contents of `<folder_to_upload>` to `<new_folder_name>` recursively, effectively renaming `<folder_to_upload>` upon upload to the archive.
 
 ### Encrypt on upload
 
-It is possible to combine the encryption and upload steps into with the use of the flag `--encrypt-with-key` followed by the path of the crypt4gh public key to be used for encryption. In this case, the input list of file arguments can only contain *unencrypted* source files. For example the following,
+It is possible to combine the encryption and upload steps into with the use of the flag `--encrypt-with-key` followed by the path of the crypt4gh public key to be used for encryption. In this case, the input list of file arguments can only contain _unencrypted_ source files. For example the following,
+
 ```bash
 ./sda-cli upload -config <configuration_file> --encrypt-with-key <public_key> <unencrypted_file_to_upload>
 ```
-will encrypt `<unencrypted_file_to_upload>` using `<public_key>` as public key and upload the created `<file_to_upload.c4gh>`  in the base folder of the user.
+
+will encrypt `<unencrypted_file_to_upload>` using `<public_key>` as public key and upload the created `<file_to_upload.c4gh>` in the base folder of the user.
 
 Encrypt on upload can be combined with any of the flags above. For example,
+
 ```bash
 ./sda-cli upload -config <configuration_file> --encrypt-with-key <public_key> -r <folder_to_upload_with_unencrypted_data> -targetDir <new_folder_name>
 ```
+
 will first encrypt all files in `<folder_to_upload_with_unencrypted_data>` and then upload the folder recursively (selecting only the created `c4gh` files) under `<new_folder_name>`.
 
 **Notes**: The tool calls the [encrypt](#Encrypt) module internally, therefore similar behavior to that command is expected, including the creation of hash files. In addition,
 
-- For encryption with [multiple public keys](#Encrypt-file(s)-with-multiple-keys), concatenate all public keys into one file and pass it as the argument to `encrypt-with-key`.
+- For encryption with [multiple public keys](<#Encrypt-file(s)-with-multiple-keys>), concatenate all public keys into one file and pass it as the argument to `encrypt-with-key`.
 - If the input includes encrypted files, the tool will exit without performing further tasks.
 - The encrypted files will be created next to their unencrypted counterparts.
 - The tool will not overwrite existing encrypted files. It will exit early if encrypted counterparts of the source files already exist with the same source path.
@@ -149,44 +176,55 @@ will first encrypt all files in `<folder_to_upload_with_unencrypted_data>` and t
 ## Get dataset size
 
 Before downloading a dataset or a specific file, the `sda-cli` tool allows for requesting the size of each file, as well as the whole dataset. In order to use this functionality, the tool expects as an argument a file containing the location of the files in the dataset. The argument can be one of the following:
+
 1. a URL to the file containing the locations of the dataset files
 2. a URL to a folder containing the `urls_list.txt` file with the locations of the dataset files
 3. the path to a local file containing the locations of the dataset files.
 
 Given this argument, the dataset size can be retrieved using the following command:
+
 ```bash
 ./sda-cli datasetsize <urls_file>
 ```
+
 where `urls_file` as described above.
 
 ## List files
 
 The uploaded files can be listed using the `list` parameter. This feature returns all the files in the user's bucket recursively and can be executed using:
+
 ```bash
 ./sda-cli list [-config <configuration_file>]
 ```
- It also allows for requesting files/filepaths with a specified prefix using:
- ```bash
+
+It also allows for requesting files/filepaths with a specified prefix using:
+
+```bash
 ./sda-cli list [-config <configuration_file>] <prefix>
 ```
+
 This command will return any file/path starting with the defined `<prefix>`.
 If no config is given by the user, the tool will look for a previous login from the user.
 
 ## Download
 
 The SDA/BP archive enables for downloading files and datasets in a secure manner. That can be achieved using the `sda-cli` tool and and it can be done in two ways:
+
 - by downloading from a S3 bucket (`./sda-cli download`)
 - by using the download API (`./sda-cli sda-download`)
 
 ### Download from S3 bucket
+
 This process consists of the following two steps: create keys and downloading the file. These steps are explained in the following sections.
 
 #### Create keys
 
 In order to make sure that the files are downloaded from the archive in a secure manner, the user is supposed to create the key pair that the files will be encrypted with. The key pair can be created using the following command:
+
 ```bash
 ./sda-cli createKey <keypair_name>
 ```
+
 where `<keypair_name>` is the base name of the key files. This command will create two keys named `keypair_name.pub.pem` and `keypair_name.sec.pem`. The public key (`pub`) will be used for the encryption of the files, while the private one (`sec`) will be used in the decryption step below.
 
 **NOTE:** Make sure to keep these keys safe. Losing the keys could lead to sensitive data leaks.
@@ -194,19 +232,24 @@ where `<keypair_name>` is the base name of the key files. This command will crea
 #### Download file
 
 The `sda-cli` tool allows for downloading file(s)/datasets. The URLs of the respective dataset files that are available for downloading are stored in a file named `urls_list.txt`. `sda-cli` allows to download files only by using such a file or the URL where it is stored. There are three different ways to pass the location of the file to the tool, similar to the [dataset size section](#get-dataset-size):
+
 1. a direct URL to `urls_list.txt` or a file with a different name but containing the locations of the dataset files
 2. a URL to a folder containing the `urls_list.txt` file
 3. the path to a local file containing the locations of the dataset files.
 
 Given this argument, the whole dataset can be retrieved using the following command:
+
 ```bash
 ./sda-cli download <urls_file>
 ```
+
 where `urls_file` as described above.
 The tool also allows for selecting a folder where the files will be downloaded, using the `outdir` argument like:
+
 ```bash
 ./sda-cli download -outdir <outdir> <urls_file>
 ```
+
 **Note**: If needed, the user can download a selection of files from an available dataset by providing a customized `urls_list.txt` file.
 
 ### Download using the download API
@@ -217,79 +260,107 @@ For downloading files the user also needs to know the download service URL and t
 #### Download specific files of the dataset
 
 For downloading one specific file the user needs to provide the path of this file by running the command below:
+
 ```bash
-./sda-cli sda-download -config <configuration_file> -datasetID <datasetID> -url <download-service-URL> <filepath>
+./sda-cli sda-download -config <configuration_file> -dataset-id <datasetID> -url <download-service-URL> <filepath>
 ```
+
 where `<configuration_file>` the file downloaded in the [previous step](#download-the-configuration-file), `<dataset_id>` the ID of the dataset and `<filepath>` the path of the file in the dataset.
 The tool also allows for downloading multiple files at once, by listing their filepaths separated with space and it also allows for selecting a folder where the files will be downloaded, using the `outdir` argument:
+
 ```bash
-./sda-cli sda-download -config <configuration_file> -datasetID <datasetID> -url <download-service-url> -outdir <outdir> <filepath_1_to_download> <filepath_2_to_download> ...
+./sda-cli sda-download -config <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> <filepath_1_to_download> <filepath_2_to_download> ...
 ```
 
 #### Download all the files of the dataset
 
 For downloading the whole dataset the user needs add the `--dataset` flag and NOT providing any filepaths:
+
 ```bash
-./sda-cli sda-download -config <configuration_file> -dataset <datasetID> -url <download-service-url> -outdir <outdir> --dataset 
+./sda-cli sda-download -config <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> --dataset
 ```
+
 where the dataset will be downloaded in the `<outdir>` directory be keeping the original folder structure of the dataset.
 
 #### Download encrypted files using the download API
 
 When a [public key](#create-keys) is provided, you can download files that are encrypted on the server-side with that public key. The command is similar to downloading the unencrypted files except that a public key is provided through the `-pubkey` flag. For example:
+
 ```bash
-./sda-cli sda-download -pubkey <public-key-file> -config <configuration_file> -dataset <datasetID> -url <download-service-url> -outdir <outdir> <filepath_1_to_download> <filepath_2_to_download> ...
+./sda-cli sda-download -pubkey <public-key-file> -config <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> <filepath_1_to_download> <filepath_2_to_download> ...
 ```
+
 After a successful download, the encrypted files can be [decrypted](#decrypt-file) using the private key corresponding to the provided public key.
+
+#### Download files recursively
+
+For downloading the content of a folder (including subfolders) the user need to add the `--recursive` flag followed by the path(s) of the folder(s):
+
+```bash
+./sda-cli sda-download -config <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> --recursive path/to/folder1 path/to/folder2 ...
+```
 
 ## Decrypt file
 
 Given that the instructions in the [download section](#download) have been followed, the key pair and the data files should be stored in some location. The last step is to decrypt the files in order to access their content. That can be achieved using the following command:
+
 ```bash
 ./sda-cli decrypt -key <keypair_name>.sec.pem <file_to_decrypt>
 ```
-where `<keypair_name>.sec.pem` the private key created in the [relevant section](#create-keys) and `<file_to_decrypt>` one of the files downloaded following the instructions of the [download section](#download-file).
 
+where `<keypair_name>.sec.pem` the private key created in the [relevant section](#create-keys) and `<file_to_decrypt>` one of the files downloaded following the instructions of the [download section](#download-file).
 
 ## Login
 
 You can login to download the configuration file needed for some of the the tool's operation using the login command:
+
 ```bash
 ./sda-cli login <login_target>
 ```
+
 where `login_target` is the URL to the `sda-auth` service from the [sensitive-data-archive](https://github.com/neicnordic/sensitive-data-archive/) project.
 
 This will open a link for the user where they can go and log in.
 After the login is complete, a configuration file will be created in the tool's directory with the name of `.sda-cli-session`
 
 ## Version
+
 You can get the current version of the sda-cli by running:
+
 ```bash
 ./sda-cli version
 ```
 
 ## Htsget
 
-You can download a (partial) file using the htsget server. You can define the name of the file you want to save the result to by using the `output`  variable. If `output` is not defined, the file will keep it's original name. If the file already exists, it will not be over-written unless you use the `--force-overwrite` flag. `filename`, `host`, and `key` are required. `reference` refers to the part of the file you wish to download.
+You can download a (partial) file using the htsget server. You can define the name of the file you want to save the result to by using the `output` variable. If `output` is not defined, the file will keep it's original name. If the file already exists, it will not be over-written unless you use the `--force-overwrite` flag. `filename`, `host`, and `key` are required. `reference` refers to the part of the file you wish to download.
+
 ```bash
 htsget -dataset <datasetID> -filename <filename> -reference <reference-number> -host <htsget-hostname> -pubkey <public-key-file> -output <file>
 ```
+
 for example:
+
 ```
 ./sda-cli htsget -config testing/s3cmd.conf -dataset DATASET0001 -filename htsnexus_test_NA12878 -reference 11 -host http://localhost:8088 -pubkey testing/c4gh.pub.pem -output ~/tmp/result.c4gh --force-overwrite
 ```
 
 # Developers' section
+
 This section contains the information required to install, modify and run the `sda-cli` tool.
 
 ## Requirements
+
 The `sda-cli` is written in golang. In order to be able to modify, build and run the tool, golang (>= 1.22) needs to be installed. The instructions for installing `go` can be found [here](https://go.dev/doc/install).
 
 ## Build tool
+
 To build the `sda-cli` tool run the following command from the root folder of the repository
+
 ```bash
 go build
 ```
+
 This command will create an executable file in the root folder, named `sda-cli`.
 
 # Create new release
@@ -301,6 +372,7 @@ In order for the automatic release to get triggered, the releases should be of t
 ## Update releaser
 
 Before pushing a change to the releaser, make sure to run the check for the configuration file, running:
+
 ```sh
 goreleaser check -f .goreleaser.yaml
 ```

--- a/sda_download/sda_download.go
+++ b/sda_download/sda_download.go
@@ -143,6 +143,11 @@ func SdaDownload(args []string) error {
 		if err != nil {
 			return err
 		}
+	case *recursiveDownload:
+		err = recursiveCase(config.AccessToken)
+		if err != nil {
+			return err
+		}
 	default:
 		err = fileCase(config.AccessToken)
 		if err != nil {
@@ -166,6 +171,35 @@ func datasetCase(token string) error {
 		err = downloadFile(fileURL, token, "", file.FilePath)
 		if err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+func recursiveCase(token string) error {
+	fmt.Println("Downloading content of the path(s)")
+	// get all the files of the dataset
+	files, err := getFilesInfo(*URL, *datasetID, "", token)
+	if err != nil {
+		return err
+	}
+	dirPaths := Args.Args()
+	// Loop over all the files of the dataset and
+	// check if the provided path is part of their filepath.
+	// If it is then download the file
+	for _, file := range files {
+		for _, dirPath := range dirPaths {
+			if !strings.HasSuffix(dirPath, "/") {
+				dirPath += "/"
+			}
+			if strings.Contains(file.FilePath, dirPath) {
+				fileURL := *URL + "/files/" + file.FileID
+				err = downloadFile(fileURL, token, "", file.FilePath)
+				if err != nil {
+					return err
+				}
+			}
 		}
 	}
 

--- a/sda_download/sda_download.go
+++ b/sda_download/sda_download.go
@@ -343,6 +343,10 @@ func getFileIDURL(baseURL, token, pubKeyBase64, dataset, filename string) (strin
 	var idx int
 	switch {
 	case strings.Contains(filename, "/"):
+		// If filename does not have a crypt4gh suffix, add one
+		if !strings.HasSuffix(filename, ".c4gh") {
+			filename += ".c4gh"
+		}
 		idx = slices.IndexFunc(
 			datasetFiles,
 			func(f File) bool { return strings.Contains(f.FilePath, filename) },

--- a/sda_download/sda_download.go
+++ b/sda_download/sda_download.go
@@ -132,15 +132,18 @@ func SdaDownload(args []string) error {
 		return err
 	}
 
-	// Check if dataset flag is set
-	// If it is, download all files in the dataset
-	// If it is not, download the files that are provided
-	if *datasetdownload {
+	switch {
+	// Case where the user is setting the --dataset flag
+	// then download all the files in the dataset.
+	// Case where the user is setting the --recursive flag
+	// then download the content of the path
+	// Default case, download the provided files.
+	case *datasetdownload:
 		err = datasetCase(config.AccessToken)
 		if err != nil {
 			return err
 		}
-	} else {
+	default:
 		err = fileCase(config.AccessToken)
 		if err != nil {
 			return err

--- a/sda_download/sda_download.go
+++ b/sda_download/sda_download.go
@@ -184,15 +184,21 @@ func recursiveCase(token string) error {
 	if err != nil {
 		return err
 	}
-	dirPaths := Args.Args()
+	// check all the provided paths and add a slash
+	// to each one of them if does not exist and
+	// append them in a slice
+	var dirPaths []string
+	for _, path := range Args.Args() {
+		if !strings.HasSuffix(path, "/") {
+			path += "/"
+		}
+		dirPaths = append(dirPaths, path)
+	}
 	// Loop over all the files of the dataset and
 	// check if the provided path is part of their filepath.
 	// If it is then download the file
 	for _, file := range files {
 		for _, dirPath := range dirPaths {
-			if !strings.HasSuffix(dirPath, "/") {
-				dirPath += "/"
-			}
 			if strings.Contains(file.FilePath, dirPath) {
 				fileURL := *URL + "/files/" + file.FileID
 				err = downloadFile(fileURL, token, "", file.FilePath)

--- a/sda_download/sda_download.go
+++ b/sda_download/sda_download.go
@@ -109,9 +109,9 @@ func SdaDownload(args []string) error {
 	if len(Args.Args()) == 0 && !*datasetdownload {
 		if !*recursiveDownload {
 			return fmt.Errorf("no files provided for download")
-		} else {
-			return fmt.Errorf("no folders provided for recursive download")
 		}
+
+		return fmt.Errorf("no folders provided for recursive download")
 	}
 
 	// Check if --dataset flag is set and files are provided

--- a/sda_download/sda_download_test.go
+++ b/sda_download/sda_download_test.go
@@ -130,7 +130,7 @@ func (suite *TestSuite) TestDownloadUrl() {
                 "fileId": "file1id",
 				"datasetId": "TES01",
 				"displayName": "file1",
-                "filePath": "path/to/file1",
+                "filePath": "path/to/file1.c4gh",
 				"fileName": "4293c9a7-re60-46ac-b79a-40ddc0ddd1c6"
             }
         ]`), nil


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #401 and #409.


**Description**
With this PR an enhancement has been implemented in the sda-download where the user can download recursively by providing one or multiple folder paths.
A bug is also fixed for downloading files: before is the user was giving an incomplete file path, e.g: `main/folder/dummy_fi` instead of `main/folder/dummy_file `then the file would be downloaded in the path which was given as incomplete. This PR is fixing this bug and the tool gives an error for incomplete paths.

**How to test**
Run the setup.sh script from the root of the repo: `bash .github/integration/setup/setup.sh`
Then run the following command for recursive download: `./sda-cli sda-download -config testing/s3cmd-download.conf -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-folder --recursive main/subfolder2`
for testing the bug fix run: `./sda-cli sda-download -config testing/s3cmd-download.conf -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir test-download main/subfolder/dummy_`
That should give an error.
