### PR TITLE
Feature/list datasets

### DIFF
--- a/.github/integration/tests/tests.sh
+++ b/.github/integration/tests/tests.sh
@@ -339,6 +339,26 @@ fi
 
 rm -r test-download
 
+# Check listing files in a dataset
+output=$(./sda-cli list -config testing/s3cmd-download.conf -dataset https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080)
+expected="dummy_data.c4gh 1048605 dummy_data2.c4gh 1048605 dummy_data3.c4gh 1048605"
+if [[ "${output//[$' \t\n\r']/}" == "${expected//[$' \t\n\r']/}" ]];  then
+    echo "Successfully listed files in dataset"
+else
+    echo "Failed to list files in dataset"
+    exit 1
+fi
+
+# Check listing datasets
+output=$(./sda-cli list -config testing/s3cmd-download.conf --datasets -url http://localhost:8080)
+expected="https://doi.example/ty009.sfrrss/600.45asasga"
+if [[ $output == *"$expected"* ]]; then
+    echo "Successfully listed datasets"
+else
+    echo "Failed to list datasets"
+    exit 1
+fi
+
 # Download whole dataset by using the sda-download feature
 ./sda-cli sda-download -config testing/s3cmd-download.conf -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-dataset --dataset 
 

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46 // indirect
 	github.com/shabbyrobe/gocovmerge v0.0.0-20180507124511-f6ea450bfb63 // indirect
 	golang.org/x/crypto v0.23.0 // indirect
-	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,6 @@ golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERs
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190310074541-c10a0554eabf/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=
-golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -441,6 +441,49 @@ func ListFiles(config Config, prefix string) (result *s3.ListObjectsV2Output, er
 	return result, nil
 }
 
+func ListDatasets(config Config) (result *s3.ListDirectoryBucketsOutput, err error) {
+	sess := session.Must(session.NewSession(&aws.Config{
+		// The region for the backend is always the specified one
+		// and not present in the configuration from auth - hardcoded
+		Region:           aws.String("us-west-2"),
+		Credentials:      credentials.NewStaticCredentials(config.AccessKey, config.SecretKey, config.AccessToken),
+		Endpoint:         aws.String(config.HostBase),
+		DisableSSL:       aws.Bool(!config.UseHTTPS),
+		S3ForcePathStyle: aws.Bool(true),
+	}))
+
+	svc := s3.New(sess)
+
+	result, err = svc.ListDirectoryBuckets(&s3.ListDirectoryBucketsInput{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list datasets, reason: %v", err)
+	}
+
+	return result, nil
+}
+
+func ListDataset(config Config, dataset string) (result *s3.ListDirectoryBucketsOutput, err error) {
+	sess := session.Must(session.NewSession(&aws.Config{
+		// The region for the backend is always the specified one
+		// and not present in the configuration from auth - hardcoded
+		Region:           aws.String("us-west-2"),
+		Credentials:      credentials.NewStaticCredentials(config.AccessKey, config.SecretKey, config.AccessToken),
+		Endpoint:         aws.String(config.HostBase),
+		DisableSSL:       aws.Bool(!config.UseHTTPS),
+		S3ForcePathStyle: aws.Bool(true),
+	}))
+
+	svc := s3.New(sess)
+
+	result, err = svc.ListDirectoryBuckets(&s3.ListDirectoryBucketsInput{})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to list dataset, reason: %v", err)
+	}
+
+	return result, nil
+}
+
 // Check for invalid characters
 func CheckValidChars(filename string) error {
 	re := regexp.MustCompile(`[\\:\*\?"<>\|\x00-\x1F\x7F]`)

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -130,6 +130,7 @@ func getPositional(args []string) ([]string, []string) {
 		"--force-unencrypted",
 		"-force-unencrypted",
 		"--dataset",
+		"--datasets",
 	}
 	i := 1
 	var positional []string

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -442,49 +442,6 @@ func ListFiles(config Config, prefix string) (result *s3.ListObjectsV2Output, er
 	return result, nil
 }
 
-func ListDatasets(config Config) (result *s3.ListDirectoryBucketsOutput, err error) {
-	sess := session.Must(session.NewSession(&aws.Config{
-		// The region for the backend is always the specified one
-		// and not present in the configuration from auth - hardcoded
-		Region:           aws.String("us-west-2"),
-		Credentials:      credentials.NewStaticCredentials(config.AccessKey, config.SecretKey, config.AccessToken),
-		Endpoint:         aws.String(config.HostBase),
-		DisableSSL:       aws.Bool(!config.UseHTTPS),
-		S3ForcePathStyle: aws.Bool(true),
-	}))
-
-	svc := s3.New(sess)
-
-	result, err = svc.ListDirectoryBuckets(&s3.ListDirectoryBucketsInput{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list datasets, reason: %v", err)
-	}
-
-	return result, nil
-}
-
-func ListDataset(config Config, dataset string) (result *s3.ListDirectoryBucketsOutput, err error) {
-	sess := session.Must(session.NewSession(&aws.Config{
-		// The region for the backend is always the specified one
-		// and not present in the configuration from auth - hardcoded
-		Region:           aws.String("us-west-2"),
-		Credentials:      credentials.NewStaticCredentials(config.AccessKey, config.SecretKey, config.AccessToken),
-		Endpoint:         aws.String(config.HostBase),
-		DisableSSL:       aws.Bool(!config.UseHTTPS),
-		S3ForcePathStyle: aws.Bool(true),
-	}))
-
-	svc := s3.New(sess)
-
-	result, err = svc.ListDirectoryBuckets(&s3.ListDirectoryBucketsInput{})
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to list dataset, reason: %v", err)
-	}
-
-	return result, nil
-}
-
 // Check for invalid characters
 func CheckValidChars(filename string) error {
 	re := regexp.MustCompile(`[\\:\*\?"<>\|\x00-\x1F\x7F]`)

--- a/list/list.go
+++ b/list/list.go
@@ -72,7 +72,7 @@ func List(args []string) error {
 	}
 	// case datasets
 	if *datasets {
-		err := ListDatasets(config.AccessToken)
+		err := Datasets(config.AccessToken)
 		if err != nil {
 			return err
 		}
@@ -82,7 +82,7 @@ func List(args []string) error {
 
 	// case dataset
 	if *dataset != "" {
-		err := ListDatasetFiles(config.AccessToken)
+		err := DatasetFiles(config.AccessToken)
 		if err != nil {
 			return err
 		}
@@ -103,12 +103,11 @@ func List(args []string) error {
 	return nil
 }
 
-func ListDatasetFiles(token string) error {
+func DatasetFiles(token string) error {
 	files, err := sdaDownload.GetFilesInfo(*URL, *dataset, "", token)
 	if err != nil {
 		return err
 	}
-	fmt.Println(files)
 	// Loop through the files and list them
 	for _, file := range files {
 		fmt.Printf("%s \t %d \n", file.DisplayFileName, file.DecryptedFileSize)
@@ -117,7 +116,7 @@ func ListDatasetFiles(token string) error {
 	return nil
 }
 
-func ListDatasets(token string) error {
+func Datasets(token string) error {
 	datasets, err := sdaDownload.GetDatasets(*URL, token)
 	if err != nil {
 		return err

--- a/list/list.go
+++ b/list/list.go
@@ -1,7 +1,6 @@
 package list
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 
@@ -16,13 +15,15 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help list` command
 var Usage = `
-USAGE: %s list [-config <s3config-file>] [prefix]
+USAGE: %s list [-config <s3config-file>] [prefix] (--datasets) (--dataset <dataset-name>)
 
 list:
     Lists recursively all files under the user's folder in the Sensitive
     Data Archive (SDA).  If the [prefix] parameter is used, only the
     files under the specified path will be returned. If no config is
-	specified, the tool will look for a previous session.
+	specified, the tool will look for a previous session. The --datasets
+	flag will list all datasets in the user's folder. The --dataset flag
+	will list all files in the specified dataset and the dataset size.
 `
 
 // ArgHelp is the suffix text that will be displayed after the argument list in
@@ -38,6 +39,10 @@ var Args = flag.NewFlagSet("list", flag.ExitOnError)
 var configPath = Args.String("config", "",
 	"S3 config file to use for listing.")
 
+var datasets = Args.Bool("datasets", false, "List all datasets in the user's folder.")
+
+var dataset = Args.String("dataset", "", "List all files in the specified dataset.")
+
 // List function lists the contents of an s3
 func List(args []string) error {
 	// Call ParseArgs to take care of all the flag parsing
@@ -45,11 +50,13 @@ func List(args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed parsing arguments, reason: %v", err)
 	}
+	fmt.Println("### args: ", args)
+	fmt.Println("### Args.Args(): ", Args.Args())
+	fmt.Println("datasets: ", *datasets)
+	fmt.Println("datasets: ", *dataset)
 
 	prefix := ""
-	if len(Args.Args()) > 1 {
-		return errors.New("failed to parse prefix, only one is allowed")
-	} else if len(Args.Args()) == 1 {
+	if len(Args.Args()) == 1 {
 		prefix = Args.Args()[0]
 	}
 
@@ -62,6 +69,27 @@ func List(args []string) error {
 	err = helpers.CheckTokenExpiration(config.AccessToken)
 	if err != nil {
 		return err
+	}
+	// case datasets
+	if *datasets {
+		dtsResult, err := helpers.ListDatasets(*config)
+		if err != nil {
+			return err
+		}
+		fmt.Println("Datasets:", dtsResult)
+
+		return nil
+	}
+
+	// case dataset
+	if *dataset != "" {
+		datasetResult, err := helpers.ListDataset(*config, *dataset)
+		if err != nil {
+			return err
+		}
+		fmt.Println("Datasets:", datasetResult)
+
+		return nil
 	}
 
 	result, err := helpers.ListFiles(*config, prefix)

--- a/list/list.go
+++ b/list/list.go
@@ -54,10 +54,6 @@ func List(args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed parsing arguments, reason: %v", err)
 	}
-	fmt.Println("### args: ", args)
-	fmt.Println("### Args.Args(): ", Args.Args())
-	fmt.Println("datasets: ", *datasets)
-	fmt.Println("dataset: ", *dataset)
 
 	prefix := ""
 	if len(Args.Args()) == 1 {
@@ -126,10 +122,9 @@ func ListDatasets(token string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(datasets)
 	// Loop through the datasets and list them
-	for range datasets {
-		fmt.Printf("%s \n", datasets)
+	for _, dataset := range datasets {
+		fmt.Printf("%s \n", dataset)
 	}
 
 	return nil

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -43,14 +43,6 @@ func (suite *TestSuite) TestNoConfig() {
 	assert.EqualError(suite.T(), err, "failed to load config file, reason: failed to read the configuration file")
 }
 
-func (suite *TestSuite) TestTooManyArgs() {
-
-	os.Args = []string{"list", "arg1", "arg2"}
-
-	err := List(os.Args)
-	assert.EqualError(suite.T(), err, "failed to parse prefix, only one is allowed")
-}
-
 func (suite *TestSuite) TestFunctionality() {
 
 	// Create a fake s3 backend

--- a/sda_download/sda_download.go
+++ b/sda_download/sda_download.go
@@ -141,7 +141,6 @@ func datasetCase(token string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("### files: ", files)
 	// Loop through the files and download them
 	for _, file := range files {
 		// Download URL for the file

--- a/sda_download/sda_download_test.go
+++ b/sda_download/sda_download_test.go
@@ -265,7 +265,7 @@ func (suite *TestSuite) TestGetFilesInfo() {
 	token := suite.accessToken
 	baseURL := "https://some/url"
 	datasetID := "test-dataset"
-	files, err := getFilesInfo(baseURL, datasetID, "", token)
+	files, err := GetFilesInfo(baseURL, datasetID, "", token)
 	require.NoError(suite.T(), err)
 	require.Len(suite.T(), files, 2)
 	assert.Equal(suite.T(), "file1id", files[0].FileID)
@@ -278,4 +278,20 @@ func (suite *TestSuite) TestGetFilesInfo() {
 	assert.Equal(suite.T(), "path/to/file2", files[1].FilePath)
 	assert.Equal(suite.T(), "4b40bd16-9eba-4992-af39-a7f824e612e2", files[1].FileName)
 	assert.Equal(suite.T(), "TES01", files[1].DatasetID)
+}
+
+func (suite *TestSuite) TestGetDatasets() {
+	// Mock getBody function
+	defer func() { getResponseBody = getBody }()
+	getResponseBody = func(_, _, _ string) ([]byte, error) {
+		return []byte(`["https://doi.example/ty009.sfrrss/600.45asasga"]`), nil
+	}
+
+	// Test
+	token := suite.accessToken
+	baseURL := "https://some/url"
+	datasets, err := GetDatasets(baseURL, token)
+	require.NoError(suite.T(), err)
+	// assert.Contains(suite.T(), datasets, "https://doi.example/ty009.sfrrss/600.45asasga")
+	assert.Equal(suite.T(), datasets, []string{"https://doi.example/ty009.sfrrss/600.45asasga"})
 }

--- a/testing/docker-compose.yml
+++ b/testing/docker-compose.yml
@@ -204,6 +204,8 @@ services:
     image: "ghcr.io/neicnordic/sensitive-data-archive:${TAG}-download"
     volumes:
       - ./archive_data/4293c9a7-dc50-46db-b79a-27ddc0dad1c6:/tmp/4293c9a7-dc50-46db-b79a-27ddc0dad1c6
+      - ./archive_data/1113c9a7-dc50-46db-b79a-27ddc0dad1c6:/tmp/1113c9a7-dc50-46db-b79a-27ddc0dad1c6
+      - ./archive_data/83d58910-4c53-4dad-bd8a-f10a04c1845c:/tmp/83d58910-4c53-4dad-bd8a-f10a04c1845c
     mem_limit: 256m
     ports:
       - "8080:8080"

--- a/testing/docker-compose.yml
+++ b/testing/docker-compose.yml
@@ -204,8 +204,6 @@ services:
     image: "ghcr.io/neicnordic/sensitive-data-archive:${TAG}-download"
     volumes:
       - ./archive_data/4293c9a7-dc50-46db-b79a-27ddc0dad1c6:/tmp/4293c9a7-dc50-46db-b79a-27ddc0dad1c6
-      - ./archive_data/1113c9a7-dc50-46db-b79a-27ddc0dad1c6:/tmp/1113c9a7-dc50-46db-b79a-27ddc0dad1c6
-      - ./archive_data/83d58910-4c53-4dad-bd8a-f10a04c1845c:/tmp/83d58910-4c53-4dad-bd8a-f10a04c1845c
     mem_limit: 256m
     ports:
       - "8080:8080"


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #388 .

**Description**
This PR extends the functionality of `list` to be able for the user to list the files that belong to a dataset as well as listing all the user's datasets.

**How to test**
Set-up the testing environment by running:
```
bash .github/integration/setup/setup.sh
``` 
After all services come up, test listing the user's datasets by running:
```
./sda-cli list -config testing/s3cmd-download.conf --datasets  -url http://localhost:8080
```
Test listing the files from a dataset by running:
```
./sda-cli list -config testing/s3cmd-download.conf -dataset https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080
```