### PR TITLE
Feature/download fileid

### DIFF
--- a/.github/integration/tests/tests.sh
+++ b/.github/integration/tests/tests.sh
@@ -425,4 +425,22 @@ done
 
 rm -r download-folder 
 
+# Download file by providing the file id
+./sda-cli sda-download -config testing/s3cmd-download.conf -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-fileid urn:neic:001-001
+
+# Check if file exists in the path
+if [ ! -f "download-fileid/main/subfolder/dummy_data" ]; then
+    echo "Downloaded file by using the file id not found"
+    exit 1
+fi
+
+# Check the first line of the file
+first_line_id=$(head -n 1 download-fileid/main/subfolder/dummy_data)
+if [[ $first_line_id != *"THIS FILE IS JUST DUMMY DATA"* ]]; then
+    echo "This is not the file with the given file id"
+    exit 1
+fi
+
+rm -r download-fileid
+
 echo "Integration test finished successfully"

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ For downloading files the user also needs to know the download service URL and t
 
 #### Download specific files of the dataset (using filepaths or file ids)
 
-For downloading one specific file the user needs to provide the path or the id of this file by running the command below:
+For downloading one specific file the user needs to provide the path or the id (the id should **NOT** have "/") of this file by running the command below:
 
 ```bash
 ./sda-cli sda-download -config <configuration_file> -dataset-id <datasetID> -url <download-service-URL> [<filepath> or <fileid>]

--- a/README.md
+++ b/README.md
@@ -255,21 +255,35 @@ The tool also allows for selecting a folder where the files will be downloaded, 
 ### Download using the download API
 
 The download API allows for downloading files from the archive and it requires the user to have access to the dataset, therefore a [configuration file](#download-the-configuration-file) needs to be downloaded before starting the downloading of the files.
-For downloading files the user also needs to know the download service URL and the dataset ID. The user has the option to download either the whole dataset or specific files of the dataset by providing the paths of the files.
+For downloading files the user also needs to know the download service URL and the dataset ID. The user has several options for downloading:
 
-#### Download specific files of the dataset
+- specific files by using their paths
+- specific files by using their file ids
+- multiple files recursively
+- all the files of the dataset
+- specific encrypted files
 
-For downloading one specific file the user needs to provide the path of this file by running the command below:
+#### Download specific files of the dataset (using filepaths or file ids)
+
+For downloading one specific file the user needs to provide the path or the id of this file by running the command below:
 
 ```bash
-./sda-cli sda-download -config <configuration_file> -dataset-id <datasetID> -url <download-service-URL> <filepath>
+./sda-cli sda-download -config <configuration_file> -dataset-id <datasetID> -url <download-service-URL> [<filepath> or <fileid>]
 ```
 
-where `<configuration_file>` the file downloaded in the [previous step](#download-the-configuration-file), `<dataset_id>` the ID of the dataset and `<filepath>` the path of the file in the dataset.
-The tool also allows for downloading multiple files at once, by listing their filepaths separated with space and it also allows for selecting a folder where the files will be downloaded, using the `outdir` argument:
+where `<configuration_file>` the file downloaded in the [previous step](#download-the-configuration-file), `<dataset_id>` the ID of the dataset and `<filepath>` the path of the file (or `<fileid>` the id of the file) in the dataset.
+The tool also allows for downloading multiple files at once, by listing their filepaths (or file ids) separated with space and it also allows for selecting a folder where the files will be downloaded, using the `outdir` argument:
 
 ```bash
-./sda-cli sda-download -config <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> <filepath_1_to_download> <filepath_2_to_download> ...
+./sda-cli sda-download -config <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> <path/to/file1> <other/path/to/file2> ... (or <fileID_1> <fileID_2> ...)
+```
+
+#### Download files recursively
+
+For downloading the content of a folder (including subfolders) the user need to add the `--recursive` flag followed by the path(s) of the folder(s):
+
+```bash
+./sda-cli sda-download -config <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> --recursive path/to/folder1 path/to/folder2 ...
 ```
 
 #### Download all the files of the dataset
@@ -291,14 +305,6 @@ When a [public key](#create-keys) is provided, you can download files that are e
 ```
 
 After a successful download, the encrypted files can be [decrypted](#decrypt-file) using the private key corresponding to the provided public key.
-
-#### Download files recursively
-
-For downloading the content of a folder (including subfolders) the user need to add the `--recursive` flag followed by the path(s) of the folder(s):
-
-```bash
-./sda-cli sda-download -config <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> --recursive path/to/folder1 path/to/folder2 ...
-```
 
 ## Decrypt file
 

--- a/sda_download/sda_download.go
+++ b/sda_download/sda_download.go
@@ -45,10 +45,10 @@ var ArgHelp = `
 		All flagless arguments will be used as sda-download uri.
 	[filepath(s)]
 		The filepath of the file to download.
-    [fileid(s)]
-        The file ID of the file to download.
-    [dirpath]
-        The directory path to download all files recursively.`
+    	[fileid(s)]
+        	The file ID of the file to download.
+    	[dirpath]
+        	The directory path to download all files recursively.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/sda_download/sda_download.go
+++ b/sda_download/sda_download.go
@@ -25,7 +25,7 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help download` command
 var Usage = `
-USAGE: %s sda-download -config <s3config-file> -dataset-id <datasetID> -url <uri> (--pubkey <public-key-file>) (-outdir <dir>) ([filepath(s)] or --dataset or --recursive <dirpath>)
+USAGE: %s sda-download -config <s3config-file> -dataset-id <datasetID> -url <uri> (--pubkey <public-key-file>) (-outdir <dir>) ([filepath(s) or fileid(s)] or --dataset or --recursive <dirpath>)
 
 sda-download:
 	Downloads files from the Sensitive Data Archive (SDA) by using APIs from the given url. The user
@@ -44,8 +44,9 @@ var ArgHelp = `
 	[uri]
 		All flagless arguments will be used as sda-download uri.
 	[filepath(s)]
-		The filepath of the file to download. If no filepath is provided
-        then the whole dataset will be downloaded.
+		The filepath of the file to download.
+    [fileid(s)]
+        The file ID of the file to download.
     [dirpath]
         The directory path to download all files recursively.`
 
@@ -249,12 +250,12 @@ func fileCase(token string) error {
 
 	// Loop through the files and download them
 	for _, filePath := range files {
-		fileIDURL, err := getFileIDURL(*URL, token, pubKeyBase64, *datasetID, filePath)
+		fileIDURL, apiFilePath, err := getFileIDURL(*URL, token, pubKeyBase64, *datasetID, filePath)
 		if err != nil {
 			return err
 		}
 
-		err = downloadFile(fileIDURL, token, pubKeyBase64, filePath)
+		err = downloadFile(fileIDURL, token, pubKeyBase64, apiFilePath)
 		if err != nil {
 			return err
 		}
@@ -332,12 +333,12 @@ func downloadFile(uri, token, pubKeyBase64, filePath string) error {
 }
 
 // getFileIDURL gets the datset files, parses the JSON response to get the file ID
-// and returns the download URL for the file
-func getFileIDURL(baseURL, token, pubKeyBase64, dataset, filename string) (string, error) {
+// and returns the download URL for the file and the filepath from the API response
+func getFileIDURL(baseURL, token, pubKeyBase64, dataset, filename string) (string, string, error) {
 	// Get the files of the dataset
 	datasetFiles, err := GetFilesInfo(baseURL, dataset, pubKeyBase64, token)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	// Get the file ID for the filename
@@ -360,7 +361,7 @@ func getFileIDURL(baseURL, token, pubKeyBase64, dataset, filename string) (strin
 	}
 
 	if idx == -1 {
-		return "", fmt.Errorf("File not found in dataset %s", filename)
+		return "", "", fmt.Errorf("File not found in dataset %s", filename)
 	}
 
 	var url string
@@ -371,7 +372,7 @@ func getFileIDURL(baseURL, token, pubKeyBase64, dataset, filename string) (strin
 		url = baseURL + "/s3-encrypted/" + dataset + "/" + filename
 	}
 
-	return url, nil
+	return url, datasetFiles[idx].FilePath, nil
 }
 
 func GetDatasets(baseURL, token string) ([]string, error) {

--- a/sda_download/sda_download_test.go
+++ b/sda_download/sda_download_test.go
@@ -146,28 +146,28 @@ func (suite *TestSuite) TestDownloadUrl() {
 	// Test with an empty public key
 
 	// Test with valid base_url, token, dataset, and filename
-	url, err := getFileIDURL(baseURL, token, "", datasetID, filepath)
+	url, _, err := getFileIDURL(baseURL, token, "", datasetID, filepath)
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), expectedURL, url)
 
 	// Test with url as dataset
 	datasetID = "https://doi.example/another/url/001"
-	_, err = getFileIDURL(baseURL, token, "", datasetID, filepath)
+	_, _, err = getFileIDURL(baseURL, token, "", datasetID, filepath)
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), expectedURL, url)
 
 	// Test with filename not in response
 	filepath = "path/to/file2"
-	_, err = getFileIDURL(baseURL, token, "", datasetID, filepath)
+	_, _, err = getFileIDURL(baseURL, token, "", datasetID, filepath)
 	assert.Error(suite.T(), err)
 
 	// Test with fileID
 	filepath = "file1id"
-	_, err = getFileIDURL(baseURL, token, "", datasetID, filepath)
+	_, _, err = getFileIDURL(baseURL, token, "", datasetID, filepath)
 	assert.NoError(suite.T(), err)
 
 	// Testr with bad URL
-	_, err = getFileIDURL("some/url", token, "", datasetID, filepath)
+	_, _, err = getFileIDURL("some/url", token, "", datasetID, filepath)
 	assert.Error(suite.T(), err)
 
 	//-----------------------------------------------
@@ -175,24 +175,24 @@ func (suite *TestSuite) TestDownloadUrl() {
 	// Test with valid base_url, token, dataset, and filename
 	expectedURL = baseURL + "/s3-encrypted/" + datasetID + "/" + filepath
 	pubKey := "test-public-key"
-	url, err = getFileIDURL(baseURL, token, pubKey, datasetID, filepath)
+	url, _, err = getFileIDURL(baseURL, token, pubKey, datasetID, filepath)
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), expectedURL, url)
 
 	// Test with url as dataset
 	datasetID = "https://doi.example/another/url/001"
 	expectedURL = baseURL + "/s3-encrypted/" + datasetID + "/" + filepath
-	url, err = getFileIDURL(baseURL, token, pubKey, datasetID, filepath)
+	url, _, err = getFileIDURL(baseURL, token, pubKey, datasetID, filepath)
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), expectedURL, url)
 
 	// Test with filename not in response
 	filepath = "path/to/file2"
-	_, err = getFileIDURL(baseURL, token, pubKey, datasetID, filepath)
+	_, _, err = getFileIDURL(baseURL, token, pubKey, datasetID, filepath)
 	assert.Error(suite.T(), err)
 
 	// Testr with bad URL
-	_, err = getFileIDURL("some/url", token, pubKey, datasetID, filepath)
+	_, _, err = getFileIDURL("some/url", token, pubKey, datasetID, filepath)
 	assert.Error(suite.T(), err)
 }
 


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #414.


**Description**
It was implemented in the sda_download that the user can download files by providing the file id. 
This PR:
- fixes the download path which was wrong when this case was used
- added this case in the integration test
- updated the readme file with info about downloading by providing the file id 

**How to test**
Spin up containers by running:
```bash
bash .github/integration/setup/setup.sh
```
and then run:
```bash
./sda-cli sda-download -config testing/s3cmd-download.conf -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-fileid urn:neic:001-001
```
and you should see the file in the `download-fileid/main/subfolder/dummy_data` path
