### PR TITLE
Extend invalid characters for checking

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -446,7 +446,7 @@ func ListFiles(config Config, prefix string) (result *s3.ListObjectsV2Output, er
 
 // Check for invalid characters
 func CheckValidChars(filename string) error {
-	re := regexp.MustCompile(`[\\:\*\?"<>\|\x00-\x1F\x7F]`)
+	re := regexp.MustCompile(`[\\<>"\|\x00-\x1F\x7F\!\*\'\(\)\;\:\@\&\=\+\$\,\?\%\#\[\]]`)
 	dissallowedChars := re.FindAllString(filename, -1)
 	if dissallowedChars != nil {
 		return fmt.Errorf(

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -447,12 +447,12 @@ func ListFiles(config Config, prefix string) (result *s3.ListObjectsV2Output, er
 // Check for invalid characters
 func CheckValidChars(filename string) error {
 	re := regexp.MustCompile(`[\\<>"\|\x00-\x1F\x7F\!\*\'\(\)\;\:\@\&\=\+\$\,\?\%\#\[\]]`)
-	dissallowedChars := re.FindAllString(filename, -1)
-	if dissallowedChars != nil {
+	disallowedChars := re.FindAllString(filename, -1)
+	if disallowedChars != nil {
 		return fmt.Errorf(
 			"filepath %v contains disallowed characters: %+v",
 			filename,
-			strings.Join(dissallowedChars, ", "),
+			strings.Join(disallowedChars, ", "),
 		)
 	}
 

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -406,7 +406,8 @@ public_key = 27be42445fd9e39c9be39e6b36a55e61e3801fc845f63781a813d3fe9977e17a
 
 func (suite *HelperTests) TestInvalidCharacters() {
 	// Test that file paths with invalid characters trigger errors
-	for _, badc := range "\x00\x7F\x1A:*?\\" {
+	invalidChars := `\<>"|\!*'();:@&=+$,?#[]`
+	for _, badc := range invalidChars {
 		badchar := string(badc)
 		testfilepath := "test" + badchar + "file"
 

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -406,8 +406,7 @@ public_key = 27be42445fd9e39c9be39e6b36a55e61e3801fc845f63781a813d3fe9977e17a
 
 func (suite *HelperTests) TestInvalidCharacters() {
 	// Test that file paths with invalid characters trigger errors
-	invalidChars := `\<>"|\!*'();:@&=+$,?#[]`
-	for _, badc := range invalidChars {
+	for _, badc := range "\x00\x7F\x1A:*?\\<>\"|!'();@&=+$,%#[]" {
 		badchar := string(badc)
 		testfilepath := "test" + badchar + "file"
 


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #330 


**Description**
The set of invalid characters is extended to match with s3inbox, see [this PR](https://github.com/neicnordic/sensitive-data-archive/pull/965/files) for details.

**How to test**
