### PR TITLE
Feature/list dataset show more info

### DIFF
--- a/.github/integration/tests/tests.sh
+++ b/.github/integration/tests/tests.sh
@@ -169,7 +169,7 @@ rm -r test-download
 
 # Check listing files in a dataset
 output=$(./sda-cli list -config testing/s3cmd-download.conf -dataset https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080)
-expected="dummy_data.c4gh 1048605 dummy_data2.c4gh 1048605 dummy_data3.c4gh 1048605"
+expected="FileIDSizePathurn:neic:001-0011.0MB5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8_elixir-europe.org/main/subfolder/dummy_data.c4ghurn:neic:001-0021.0MB5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8_elixir-europe.org/main/subfolder2/dummy_data2.c4ghurn:neic:001-0031.0MB5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8_elixir-europe.org/main/subfolder2/random/dummy_data3.c4ghDatasetsize:3.1MB"
 if [[ "${output//[$' \t\n\r']/}" == "${expected//[$' \t\n\r']/}" ]];  then
     echo "Successfully listed files in dataset"
 else

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dchest/bcrypt_pbkdf v0.0.0-20150205184540-83f37f9c154a // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/bcrypt_pbkdf v0.0.0-20150205184540-83f37f9c154a h1:saTgr5tMLFnmy/yg3qDTft4rE5DY2uJ/cCxCe3q0XTU=
 github.com/dchest/bcrypt_pbkdf v0.0.0-20150205184540-83f37f9c154a/go.mod h1:Bw9BbhOJVNR+t0jCqx2GC6zv0TGBsShs56Y3gfSCvl0=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/inhies/go-bytesize v0.0.0-20210819104631-275770b98743 h1:X3Xxno5Ji8idrNiUoFc7QyXpqhSYlDRYQmc7mlpMBzU=

--- a/list/list.go
+++ b/list/list.go
@@ -18,7 +18,7 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help list` command
 var Usage = `
-USAGE: %s list [--config <s3config-file>] [prefix] (-url <uri> --datasets) (-url <uri> --dataset <dataset-id>) [--bytes]
+USAGE: %s list [-config <s3config-file>] [prefix] (-url <uri> --datasets) (-url <uri> --dataset <dataset-id>) [-bytes]
 
 list:
     Lists recursively all files under the user's folder in the Sensitive

--- a/list/list.go
+++ b/list/list.go
@@ -3,11 +3,13 @@ package list
 import (
 	"flag"
 	"fmt"
+	"strconv"
 
 	"strings"
 
 	"github.com/NBISweden/sda-cli/download"
 	"github.com/NBISweden/sda-cli/helpers"
+	"github.com/dustin/go-humanize"
 	"github.com/inhies/go-bytesize"
 )
 
@@ -16,7 +18,7 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help list` command
 var Usage = `
-USAGE: %s list [-config <s3config-file>] [prefix] (-url <uri> --datasets) (-url <uri> --dataset <dataset-id>)
+USAGE: %s list [--config <s3config-file>] [prefix] (-url <uri> --datasets) (-url <uri> --dataset <dataset-id>) [--bytes]
 
 list:
     Lists recursively all files under the user's folder in the Sensitive
@@ -44,6 +46,8 @@ var configPath = Args.String("config", "",
 var URL = Args.String("url", "", "The url of the sda-download server")
 
 var datasets = Args.Bool("datasets", false, "List all datasets in the user's folder.")
+
+var bytesFormat = Args.Bool("bytes", false, "Print file sizes in bytes (not human-readable format).")
 
 var dataset = Args.String("dataset", "", "List all files in the specified dataset.")
 
@@ -108,10 +112,23 @@ func DatasetFiles(token string) error {
 	if err != nil {
 		return err
 	}
+	formatedBytes := func(size int) string {
+		if !*bytesFormat {
+			return humanize.Bytes(uint64(size))
+		}
+
+		return strconv.Itoa(size)
+	}
+	// Set rather long minimum column widths, so that header matches the rest of the table
+	fileIDWidth, sizeWidth := 20, 10
+	fmt.Printf("%-*s \t %-*s \t %s\n", fileIDWidth, "FileID", sizeWidth, "Size", "Path")
+	datasetSize := 0
 	// Loop through the files and list them
 	for _, file := range files {
-		fmt.Printf("%s \t %d \n", file.DisplayFileName, file.DecryptedFileSize)
+		datasetSize += file.DecryptedFileSize
+		fmt.Printf("%s \t %s \t %s\n", file.FileID, formatedBytes(file.DecryptedFileSize), file.FilePath)
 	}
+	fmt.Printf("Dataset size: %s\n", formatedBytes(datasetSize))
 
 	return nil
 }

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -354,7 +354,7 @@ func (suite *TestSuite) TestRecursiveToDifferentTarget() {
 	}
 	_, err := s3Client.CreateBucket(cparams)
 	if err != nil {
-		log.Printf(err.Error())
+		log.Print(err.Error())
 	}
 
 	// Create conf file for sda-cli
@@ -377,7 +377,7 @@ func (suite *TestSuite) TestRecursiveToDifferentTarget() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd.conf")
 	if err != nil {
-		log.Printf(err.Error())
+		log.Print(err.Error())
 	}
 	defer os.Remove(configPath.Name())
 
@@ -419,7 +419,7 @@ func (suite *TestSuite) TestRecursiveToDifferentTarget() {
 		Bucket: aws.String("dummy"),
 	})
 	if err != nil {
-		log.Printf(err.Error())
+		log.Print(err.Error())
 	}
 	assert.Equal(suite.T(), filepath.ToSlash(filepath.Join(targetPath, filepath.Base(dir), filepath.Base(testfile.Name()))), aws.StringValue(result.Contents[0].Key))
 


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #433.

**Description**
- `sda-cli list --dataset X` will print the file ID, file size (in human or machine readable form) and file path of each file in dataset X. Also the dataset size will be printed.
- flag `--bytes` is added, defaulting to `false`. If `true`, file sizes are printed in byte format.

**How to test**
From the root folder run the setup script:
```
bash .github/integration/setup/setup.sh
```
(note to future self: if it does not work, remove all containers and run `docker volume rm -f $(docker volume ls -f "dangling=true")`).
Then run:
```
./sda-cli list -config testing/s3cmd-download.conf -dataset https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 
```
And get
```
FileID               	 Size       	 Path
urn:neic:001-001 	 1.0 MB 	 5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8_elixir-europe.org/main/subfolder/dummy_data.c4gh
urn:neic:001-002 	 1.0 MB 	 5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8_elixir-europe.org/main/subfolder2/dummy_data2.c4gh
urn:neic:001-003 	 1.0 MB 	 5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8_elixir-europe.org/main/subfolder2/random/dummy_data3.c4gh
Dataset size: 3.1 MB
```