### PR TITLE
List datasets more info

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -139,9 +139,24 @@ func Datasets(token string) error {
 	if err != nil {
 		return err
 	}
+
 	// Loop through the datasets and list them
 	for _, dataset := range datasets {
-		fmt.Printf("%s \n", dataset)
+		files, err := download.GetFilesInfo(*URL, dataset, "", token)
+		if err != nil {
+			return err
+		}
+		// Set rather long minimum column widths, so that header matches the rest of the table
+		fileIDWidth := 40
+		fmt.Printf("%-*s \t %s \t %s\n", fileIDWidth, "DatasetID", "Files", "Size")
+		datasetSize := 0
+		noOfFiles := 0
+		// Loop through the files and get their sizes
+		for _, file := range files {
+			datasetSize += file.DecryptedFileSize
+			noOfFiles++
+		}
+		fmt.Printf("%s \t %d \t %s\n", dataset, noOfFiles, formatedBytes(datasetSize))
 	}
 
 	return nil

--- a/list/list.go
+++ b/list/list.go
@@ -112,13 +112,6 @@ func DatasetFiles(token string) error {
 	if err != nil {
 		return err
 	}
-	formatedBytes := func(size int) string {
-		if !*bytesFormat {
-			return humanize.Bytes(uint64(size))
-		}
-
-		return strconv.Itoa(size)
-	}
 	// Set rather long minimum column widths, so that header matches the rest of the table
 	fileIDWidth, sizeWidth := 20, 10
 	fmt.Printf("%-*s \t %-*s \t %s\n", fileIDWidth, "FileID", sizeWidth, "Size", "Path")
@@ -131,6 +124,14 @@ func DatasetFiles(token string) error {
 	fmt.Printf("Dataset size: %s\n", formatedBytes(datasetSize))
 
 	return nil
+}
+
+func formatedBytes(size int) string {
+	if !*bytesFormat {
+		return humanize.Bytes(uint64(size))
+	}
+
+	return strconv.Itoa(size)
 }
 
 func Datasets(token string) error {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #438 .

**Description**
`sda-cli list -datasets` will print number of files and dataset size:
```
DatasetID                                	 Files 	 Size
https://doi.example/ty009.sfrrss/600.45asasga 	 3 	 3.1 MB
https://doi.example/ty009.sfrrss/Dataset         1 	 1.1 MB
```

**How to test**
From the root folder run the setup script:
```
bash .github/integration/setup/setup.sh
```
(note to future self: if it does not work, remove all containers and run `docker volume rm -f $(docker volume ls -f "dangling=true")`).
Then run:
```
./sda-cli list -config testing/s3cmd-download.conf -datasets -url http://localhost:8080 
```
And get
```
DatasetID                                	 Files 	 Size
https://doi.example/ty009.sfrrss/600.45asasga 	 3 	 3.1 MB
```