### PR TITLE
Decrypt multiple files without aborting 

### DIFF
--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -84,7 +84,7 @@ func Decrypt(args []string) error {
 	for i, file := range files {
 		switch {
 		case !helpers.FileIsReadable(file.Encrypted):
-			fmt.Fprintf(os.Stderr, "Warning: cannot read input file %s\n", file.Encrypted)
+			fmt.Fprintf(os.Stderr, "Error: cannot read input file %s\n", file.Encrypted)
 		case *forceOverwrite:
 			fmt.Printf("Decrypting file %v/%v: %s\n", i+1, numFiles, file.Encrypted)
 			err := decryptFile(file.Encrypted, file.Unencrypted, *privateKey)

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -79,26 +79,40 @@ func Decrypt(args []string) error {
 		return err
 	}
 
+	var warnings []string
 	// Check that all the encrypted files exist, and all the unencrypted don't
 	for _, file := range files {
 		// check that the input file exists and is readable
 		if !helpers.FileIsReadable(file.Encrypted) {
-			return fmt.Errorf("cannot read input file %s", file.Encrypted)
+			warnings = append(warnings, fmt.Sprintf("Warning: cannot read input file %s", file.Encrypted))
+			continue
 		}
 
 		// check that the output file doesn't exist
 		if helpers.FileExists(file.Unencrypted) && !*forceOverwrite {
-			return fmt.Errorf("outfile %s already exists", file.Unencrypted)
+			warnings = append(warnings, fmt.Sprintf("Warning: output file %s already exists", file.Unencrypted))
+		}
+	}
+
+	// Print warnings if any
+	if len(warnings) > 0 {
+		for _, warning := range warnings {
+			fmt.Println(warning)
 		}
 	}
 
 	// decrypt the input files
 	numFiles := len(files)
 	for i, file := range files {
-		fmt.Printf("Decrypting file %v/%v: %s\n", i+1, numFiles, file.Encrypted)
-		err = decryptFile(file.Encrypted, file.Unencrypted, *privateKey)
-		if err != nil {
-			return err
+		if helpers.FileIsReadable(file.Encrypted) && !helpers.FileExists(file.Unencrypted) || *forceOverwrite {
+			fmt.Printf("Decrypting file %v/%v: %s\n", i+1, numFiles, file.Encrypted)
+			err := decryptFile(file.Encrypted, file.Unencrypted, *privateKey)
+			if err != nil {
+				fmt.Printf("Error decrypting file %s: %v\n", file.Encrypted, err)
+			}
+		} else if helpers.FileExists(file.Unencrypted) {
+			// Skip decrypting if the file already exists and forceOverwrite is not set
+			fmt.Printf("Skipping decryption for file %s as it already exists and forceOverwrite is not enabled\n", file.Unencrypted)
 		}
 	}
 

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -85,6 +85,7 @@ func Decrypt(args []string) error {
 		// check that the input file exists and is readable
 		if !helpers.FileIsReadable(file.Encrypted) {
 			warnings = append(warnings, fmt.Sprintf("Warning: cannot read input file %s", file.Encrypted))
+
 			continue
 		}
 

--- a/decrypt/decrypt_test.go
+++ b/decrypt/decrypt_test.go
@@ -242,8 +242,7 @@ func (suite *DecryptTests) TestDecryptMultipleFiles() {
 	}
 
 	// Now, run decryption again with --force-overwrite enabled
-	os.Args = []string{"decrypt", "-key", fmt.Sprintf("%s.sec.pem", testKeyFile),
-		"--force-overwrite", encryptedFiles[0], encryptedFiles[1], encryptedFiles[2]}
+	os.Args = []string{"decrypt", "-key", fmt.Sprintf("%s.sec.pem", testKeyFile), "--force-overwrite", encryptedFiles[0], encryptedFiles[1], encryptedFiles[2]}
 
 	err = Decrypt(os.Args)
 	assert.NoError(suite.T(), err, "decrypt with --force-overwrite failed unexpectedly")


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #446 


**Description**
When decrypting multiple files, `sda-cli` would previously abort the process if it encountered an existing decrypted file or a missing encrypted file. After the fix, the process will continue in such cases, and warning messages will be printed instead.


**How to test**
Create some files, e.g. file1.txt file2.txt file3.txt, file4.txt and encrypt them with a public key. 
remove some unencrypted files. 
run the command with 
```
sda-cli decrypt -key private-key-file file*.txt.c4gh nonexist.c4gh
```
Those encrypted files without any existing decrypted files will be decrypted and warning messages will be printed.  

