### PR TITLE
Public key file permissions set to full read access

### DIFF
--- a/create_key/create_key.go
+++ b/create_key/create_key.go
@@ -100,7 +100,7 @@ func GenerateKeyPair(basename, password string) error {
 	}
 
 	// Save keys to file
-	pubFile, err := os.OpenFile(filepath.Clean(publicKeyName), os.O_WRONLY|os.O_CREATE, 0600)
+	pubFile, err := os.OpenFile(filepath.Clean(publicKeyName), os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}

--- a/create_key/create_key_test.go
+++ b/create_key/create_key_test.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/neicnordic/crypt4gh/keys"
@@ -80,12 +81,19 @@ func (suite *CreateKeyTests) TestgenerateKeyPairPermission() {
 	pubFile, err := os.Lstat(testFileName + ".pub.pem")
 	assert.NoError(suite.T(), err)
 	pubPerm := pubFile.Mode().Perm()
-	assert.Equal(suite.T(), pubPerm, fs.FileMode(0644))
+	if runtime.GOOS == "windows" {
+		assert.Equal(suite.T(), fs.FileMode(0666), pubPerm)
+	} else {
+		assert.Equal(suite.T(), fs.FileMode(0644), pubPerm)
+	}
 
 	// test that the secret key has correct permission
 	secFile, err := os.Lstat(testFileName + ".sec.pem")
 	assert.NoError(suite.T(), err)
 	secPerm := secFile.Mode().Perm()
-	assert.Equal(suite.T(), secPerm, fs.FileMode(0600))
-
+	if runtime.GOOS == "windows" {
+		assert.Equal(suite.T(), fs.FileMode(0666), pubPerm)
+	} else {
+		assert.Equal(suite.T(), fs.FileMode(0600), secPerm)
+	}
 }

--- a/create_key/create_key_test.go
+++ b/create_key/create_key_test.go
@@ -2,6 +2,7 @@ package createkey
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -65,4 +66,26 @@ func (suite *CreateKeyTests) TestgenerateKeyPair() {
 
 	_, err = keys.ReadPrivateKey(keyFile, []byte(password))
 	assert.NoError(suite.T(), err)
+}
+
+func (suite *CreateKeyTests) TestgenerateKeyPairPermission() {
+
+	testFileName := filepath.Join(suite.tempDir, "keyfile")
+
+	// none of the target files exist, no password used
+	err := GenerateKeyPair(testFileName, "")
+	assert.NoError(suite.T(), err)
+
+	// test that the public key has correct permission
+	pubFile, err := os.Lstat(testFileName + ".pub.pem")
+	assert.NoError(suite.T(), err)
+	pubPerm := pubFile.Mode().Perm()
+	assert.Equal(suite.T(), pubPerm, fs.FileMode(0644))
+
+	// test that the secret key has correct permission
+	secFile, err := os.Lstat(testFileName + ".sec.pem")
+	assert.NoError(suite.T(), err)
+	secPerm := secFile.Mode().Perm()
+	assert.Equal(suite.T(), secPerm, fs.FileMode(0600))
+
 }


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #410 .


**Description**
- The key pair created by `sda-cli` is now:
  ```
  $sda-cli createKey keys
  $ls -l
  -rw------- 1 malin malin      255 Sep 19 16:36 keys.sec.pem
  -rw-r--r-- 1 malin malin      115 Sep 19 16:36 keys.pub.pem
  ```

- A test case is added.

**How to test**
`sda-cli createKey testkeys`

