### PR TITLE
Clean up encrypted files after decryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Given that the instructions in the [download section](#download) have been follo
 ./sda-cli decrypt -key <keypair_name>.sec.pem <file_to_decrypt>
 ```
 
-where `<keypair_name>.sec.pem` the private key created in the [relevant section](#create-keys) and `<file_to_decrypt>` one of the files downloaded following the instructions of the [download section](#download-file). The `--force-overwrite` flag can be used to over-write the decrypted file if it exists and the `--clean` flag to delete the encrypted file after successful decryption.
+where `<keypair_name>.sec.pem` is the private key created in the [relevant section](#create-keys) and `<file_to_decrypt>` is one of the files downloaded following the instructions of the [download section](#download-file). The `--force-overwrite` flag can be used to over-write the decrypted file if it exists and the `--clean` flag to delete the encrypted file after successful decryption.
 
 ## Login
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Given that the instructions in the [download section](#download) have been follo
 ./sda-cli decrypt -key <keypair_name>.sec.pem <file_to_decrypt>
 ```
 
-where `<keypair_name>.sec.pem` the private key created in the [relevant section](#create-keys) and `<file_to_decrypt>` one of the files downloaded following the instructions of the [download section](#download-file).
+where `<keypair_name>.sec.pem` the private key created in the [relevant section](#create-keys) and `<file_to_decrypt>` one of the files downloaded following the instructions of the [download section](#download-file). The `--force-overwrite` flag can be used to over-write the decrypted file if it exists and the `--clean` flag to delete the encrypted file after successful decryption.
 
 ## Login
 

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -114,7 +114,7 @@ func Decrypt(args []string) error {
 		if *clean {
 			err = os.Remove(file.Encrypted)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Could not remove encrypted file %s: %s", file.Encrypted, err)
+				fmt.Fprintf(os.Stderr, "Could not remove encrypted file %s: %s\n", file.Encrypted, err)
 
 				continue
 			}
@@ -122,9 +122,11 @@ func Decrypt(args []string) error {
 		}
 
 	}
-	fmt.Printf("Decryption completed.\n%v files decrypted\n", decryptedCount)
-	if *clean {
-		fmt.Printf("%v encrypted files removed\n", removedCount)
+	if decryptedCount != numFiles {
+		fmt.Printf("WARNING: %v file(s) could not be decrypted\n", numFiles-decryptedCount)
+	}
+	if *clean && removedCount != numFiles {
+		fmt.Printf("WARNING: %v file(s) could not be removed\n", numFiles-removedCount)
 	}
 
 	return nil

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -96,6 +96,7 @@ func Decrypt(args []string) error {
 
 	// decrypt the input files
 	numFiles := len(files)
+	removedCount := 0
 	for i, file := range files {
 		fmt.Printf("Decrypting file %v/%v: %s\n", i+1, numFiles, file.Encrypted)
 		err = decryptFile(file.Encrypted, file.Unencrypted, *privateKey)
@@ -108,12 +109,12 @@ func Decrypt(args []string) error {
 			if err != nil {
 				return fmt.Errorf("could not remove encrypted file %s: %s", file.Encrypted, err)
 			}
-
-			// check that the encrypted file was removed
-			if !helpers.FileExists(file.Encrypted) {
-				fmt.Printf("Encrypted file %s was removed\n", file.Encrypted)
-			}
+			removedCount++
 		}
+	}
+	fmt.Printf("Decryption completed, %v files decrypted\n", numFiles)
+	if *clean {
+		fmt.Printf("Removed %v encrypted files\n", removedCount)
 	}
 
 	return nil

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -19,13 +19,14 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help decrypt` command
 var Usage = `
-USAGE: %s decrypt -key <private-key-file> (--force-overwrite) [file(s)]
+USAGE: %s decrypt -key <private-key-file> (--force-overwrite) (--clean) [file(s)]
 
 decrypt:
     Decrypts files from the Sensitive Data Archive (SDA) with the
     provided private key.  If the private key is encrypted, the password
     can be supplied in the C4GH_PASSWORD environment variable, or at the
-    interactive password prompt.
+    interactive password prompt. The --force-overwrite flag will overwrite
+	existing files, and the --clean flag will remove the encrypted file.
 `
 
 // ArgHelp is the suffix text that will be displayed after the argument list in
@@ -40,6 +41,7 @@ var Args = flag.NewFlagSet("decrypt", flag.ExitOnError)
 
 var privateKeyFile = Args.String("key", "", "Private key to use for decrypting files.")
 var forceOverwrite = Args.Bool("force-overwrite", false, "Force overwrite existing files.")
+var clean = Args.Bool("clean", false, "Remove the encrypted file after decryption.")
 
 // Decrypt takes a set of arguments, parses them, and attempts to decrypt the
 // given data files with the given private key file..
@@ -99,6 +101,18 @@ func Decrypt(args []string) error {
 		err = decryptFile(file.Encrypted, file.Unencrypted, *privateKey)
 		if err != nil {
 			return err
+		}
+		// remove the encrypted file if the clean flag is set
+		if *clean {
+			err = os.Remove(file.Encrypted)
+			if err != nil {
+				return fmt.Errorf("could not remove encrypted file %s: %s", file.Encrypted, err)
+			}
+
+			// check that the encrypted file was removed
+			if !helpers.FileExists(file.Encrypted) {
+				fmt.Printf("Encrypted file %s was removed\n", file.Encrypted)
+			}
 		}
 	}
 

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -94,7 +94,8 @@ func Decrypt(args []string) error {
 			err := decryptFile(file.Encrypted, file.Unencrypted, *privateKey)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error decrypting file %s: %v\n", file.Encrypted, err)
-				decryptedCount--
+
+				continue
 			}
 			decryptedCount++
 		case helpers.FileExists(file.Unencrypted):
@@ -104,12 +105,13 @@ func Decrypt(args []string) error {
 			err := decryptFile(file.Encrypted, file.Unencrypted, *privateKey)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error decrypting file %s: %v\n", file.Encrypted, err)
-				decryptedCount--
+
+				continue
 			}
 			decryptedCount++
 		}
 		// remove the encrypted file if the clean flag is set
-		if *clean && helpers.FileIsReadable(file.Encrypted) {
+		if *clean {
 			err = os.Remove(file.Encrypted)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Could not remove encrypted file %s: %s", file.Encrypted, err)

--- a/decrypt/decrypt_test.go
+++ b/decrypt/decrypt_test.go
@@ -151,8 +151,19 @@ func (suite *DecryptTests) TestDecrypt() {
 		assert.Equal(suite.T(), string(suite.fileContent), string(fileData))
 	}
 
-	os.Args = []string{"decrypt", "-key", fmt.Sprintf("%s.sec.pem", testKeyFile), "--force-overwrite", fmt.Sprintf("%s.c4gh", suite.testFile.Name())}
+	os.Args = []string{"decrypt", "-key", fmt.Sprintf("%s.sec.pem", testKeyFile), "--force-overwrite", "--clean", fmt.Sprintf("%s.c4gh", suite.testFile.Name())}
 	err = Decrypt(os.Args)
 	assert.NoError(suite.T(), err, "decrypt failed unexpectedly")
+	// Check that the encrypted file was removed
+	_, err = os.Stat(fmt.Sprintf("%s.c4gh", suite.testFile.Name()))
+	msg := "no such file or directory"
+	if runtime.GOOS == "windows" {
+		msg = "The system cannot find the file specified"
+	}
+	assert.ErrorContains(suite.T(), err, msg)
+	// check that the decrypted file was created
+	_, err = os.Stat(suite.testFile.Name())
+	assert.NoError(suite.T(), err, "decrypted file was not created")
 	os.Args = nil
+
 }

--- a/decrypt/decrypt_test.go
+++ b/decrypt/decrypt_test.go
@@ -151,21 +151,9 @@ func (suite *DecryptTests) TestDecrypt() {
 		assert.Equal(suite.T(), string(suite.fileContent), string(fileData))
 	}
 
-	os.Args = []string{"decrypt", "-key", fmt.Sprintf("%s.sec.pem", testKeyFile), "--force-overwrite", "--clean", fmt.Sprintf("%s.c4gh", suite.testFile.Name())}
+	os.Args = []string{"decrypt", "-key", fmt.Sprintf("%s.sec.pem", testKeyFile), "--force-overwrite", fmt.Sprintf("%s.c4gh", suite.testFile.Name())}
 	err = Decrypt(os.Args)
 	assert.NoError(suite.T(), err, "decrypt failed unexpectedly")
-	// Check that the encrypted file was removed
-	_, err = os.Stat(fmt.Sprintf("%s.c4gh", suite.testFile.Name()))
-	msg := "no such file or directory"
-	if runtime.GOOS == "windows" {
-		msg = "The system cannot find the file specified"
-	}
-	assert.ErrorContains(suite.T(), err, msg)
-	// check that the decrypted file was created
-	_, err = os.Stat(suite.testFile.Name())
-	assert.NoError(suite.T(), err, "decrypted file was not created")
-	os.Args = nil
-
 }
 
 func (suite *DecryptTests) TestDecryptMultipleFiles() {
@@ -281,4 +269,72 @@ func (suite *DecryptTests) TestDecryptMultipleFiles() {
 
 	// Cleanup
 	os.Args = nil
+}
+
+// create a new suite for testing decrypt with the clean flag
+type DecryptCleanTests struct {
+	suite.Suite
+	tempDir     string
+	fileContent []byte
+	testFile    *os.File
+}
+
+func TestDecryptCleanTestSuite(t *testing.T) {
+	suite.Run(t, new(DecryptCleanTests))
+}
+
+// test decrypt with clean flag
+func (suite *DecryptCleanTests) TestDecryptClean() {
+
+	var err error
+	// Create a temporary directory for our files
+	suite.tempDir, err = os.MkdirTemp(os.TempDir(), "sda-cli-test-decrypt-clean")
+	assert.NoError(suite.T(), err)
+
+	// create a test file...
+	suite.testFile, err = os.CreateTemp(suite.tempDir, "testfile-")
+	assert.NoError(suite.T(), err)
+
+	// ... create some content ...
+	suite.fileContent = []byte("This is some fine content right here.")
+	// ... and write the known content to it
+	err = os.WriteFile(suite.testFile.Name(), suite.fileContent, 0600)
+	assert.NoError(suite.T(), err)
+
+	testKeyFile := filepath.Join(suite.tempDir, "testkey")
+	err = createKey.GenerateKeyPair(testKeyFile, "")
+	assert.NoError(suite.T(), err)
+
+	// Encrypt a file using the encrypt module. change to the test directory to
+	// make sure that the checksum files end up there.
+	cwd, err := os.Getwd()
+	assert.NoError(suite.T(), err)
+	err = os.Chdir(suite.tempDir)
+	assert.NoError(suite.T(), err)
+	encryptArgs := []string{"encrypt", "-key", fmt.Sprintf("%s.pub.pem", testKeyFile), suite.testFile.Name()}
+	assert.NoError(suite.T(), encrypt.Encrypt(encryptArgs), "encrypting file for testing failed")
+	assert.NoError(suite.T(), os.Chdir(cwd))
+	os.Setenv("C4GH_PASSWORD", "")
+	if runtime.GOOS != "windows" {
+		assert.NoError(suite.T(), os.Remove(suite.testFile.Name()))
+		os.Args = []string{"decrypt", "-key", fmt.Sprintf("%s.sec.pem", testKeyFile), fmt.Sprintf("%s.c4gh", suite.testFile.Name()), "--clean"}
+		err = Decrypt(os.Args)
+		assert.NoError(suite.T(), err, "decrypt failed unexpectedly")
+		// Check that the encrypted file was removed
+		_, err = os.Stat(fmt.Sprintf("%s.c4gh", suite.testFile.Name()))
+		assert.ErrorContains(suite.T(), err, "no such file or directory")
+
+		// Check content of the decrypted file
+		inFile, err := os.Open(suite.testFile.Name())
+		assert.NoError(suite.T(), err, "unable to open decrypted file")
+		fileData, err := io.ReadAll(inFile)
+		assert.NoError(suite.T(), err, "unable to read decrypted file")
+		assert.Equal(suite.T(), string(suite.fileContent), string(fileData))
+	}
+
+	os.Args = nil
+}
+
+func (suite *DecryptCleanTests) TearDownTest() {
+	os.Remove(suite.tempDir)
 }

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -133,6 +133,8 @@ func getPositional(args []string) ([]string, []string) {
 		"--datasets",
 		"--recursive",
 		"--from-file",
+		"--clean",
+		"-clean",
 	}
 	i := 1
 	var positional []string


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #179 .


**Description**
Adds an option to delete the encrypted file(s) after successful decryption of the files(s).

**How to test**

Try decrypting using the flag `--clean`. it should remove the encrypted file and notify the user.

A snippet:
```
mkdir test && cd test
for i in {1..8}; do dd if=/dev/zero of="test$i" bs=100M count=1; done && cd ..
./sda-cli encrypt  -key key.pub.pem -outdir test test/*
./sda-cli decrypt -key key.sec.pem --force-overwrite -clean test/*.c4gh
```