### PR TITLE
config  file provided before command

### DIFF
--- a/.github/integration/tests/tests.sh
+++ b/.github/integration/tests/tests.sh
@@ -49,11 +49,11 @@ files="data_file.c4gh"
 check_encypted_file $files
 
 # Upload a specific file and check it
-./sda-cli upload -config testing/s3cmd.conf data_file.c4gh
+./sda-cli -config testing/s3cmd.conf upload data_file.c4gh
 check_uploaded_file "test/$user/data_file.c4gh" data_file.c4gh
 
 
-if ./sda-cli list -config testing/s3cmd.conf | grep -q 'data_file.c4gh'
+if ./sda-cli -config testing/s3cmd.conf list | grep -q 'data_file.c4gh'
 then
     echo "Listed file from s3 backend"
 else
@@ -62,7 +62,7 @@ else
 fi
 
 # Try to upload a file twice with the --force-overwrite flag
-output=$(./sda-cli upload -config testing/s3cmd.conf --force-overwrite data_file.c4gh)
+output=$(./sda-cli -config testing/s3cmd.conf upload --force-overwrite data_file.c4gh)
 
 # Create and encrypt multiple files in a folder
 
@@ -76,7 +76,7 @@ check_encypted_file "data_files_enc/data_file.c4gh data_files_enc/data_file1.c4g
 for k in data_file.c4gh data_file1.c4gh
 do
     # Upload and check file
-    ./sda-cli upload -config testing/s3cmd.conf --force-overwrite "data_files_enc/$k"
+    ./sda-cli -config testing/s3cmd.conf upload --force-overwrite "data_files_enc/$k"
     check_uploaded_file "test/$user/$k" "$k"
 done
 
@@ -90,7 +90,7 @@ cp data_files_enc/data_file.c4gh data_files_enc/dir1/dir2/data_file.c4gh
 cp data_files_enc/data_file.c4gh data_files_enc/dir1/dir2/data_file2.c4gh
 
 # Upload a folder recursively and a single file
-./sda-cli upload -config testing/s3cmd.conf -r data_files_enc/dir1 data_files_enc/data_file3.c4gh
+./sda-cli -config testing/s3cmd.conf upload -r data_files_enc/dir1 data_files_enc/data_file3.c4gh
 
 # Check that files were uploaded with the local path prefix `data_files_enc` stripped from the target path
 for k in dir1/data_file.c4gh dir1/dir2/data_file.c4gh dir1/dir2/data_file2.c4gh data_file3.c4gh
@@ -102,10 +102,10 @@ done
 
 # Upload a folder recursively and a single file in a specified upload folder
 uploadDir="testfolder"
-./sda-cli upload -config testing/s3cmd.conf -targetDir "$uploadDir" -r data_files_enc/dir1 data_files_enc/data_file3.c4gh
+./sda-cli -config testing/s3cmd.conf upload -targetDir "$uploadDir" -r data_files_enc/dir1 data_files_enc/data_file3.c4gh
 
 # Do it again to test that we can pass -targetDir at the end
-./sda-cli upload --force-overwrite -config testing/s3cmd.conf -r data_files_enc/dir1 data_files_enc/data_file3.c4gh -targetDir "$uploadDir"
+./sda-cli -config testing/s3cmd.conf upload --force-overwrite -r data_files_enc/dir1 data_files_enc/data_file3.c4gh -targetDir "$uploadDir"
 
 # Check that files were uploaded with the local path prefix `data_files_enc` stripped from the
 # target path and into the specified upload folder
@@ -117,7 +117,7 @@ done
 # Upload all contents of a folder recursively to a specified upload folder
 
 uploadDir="testfolder2"
-./sda-cli upload -config testing/s3cmd.conf -targetDir "$uploadDir" -r data_files_enc/dir1/.
+./sda-cli -config testing/s3cmd.conf upload -targetDir "$uploadDir" -r data_files_enc/dir1/.
 
 # Check that files were uploaded with the local path prefix `data_files_enc/dir1` stripped from the
 # target path and into the specified upload folder
@@ -132,7 +132,7 @@ mkdir data_files_unenc && mkdir data_files_unenc/dir1
 cp data_file data_files_unenc/. && cp data_file data_files_unenc/dir1/data_file1
 
 uploadDir="testEncryptUpload"
-./sda-cli upload -config testing/s3cmd.conf -encrypt-with-key sda_key.pub.pem -r data_files_unenc -targetDir "$uploadDir"
+./sda-cli -config testing/s3cmd.conf upload -encrypt-with-key sda_key.pub.pem -r data_files_unenc -targetDir "$uploadDir"
 
 check_encypted_file "data_files_unenc/data_file.c4gh" "data_files_unenc/dir1/data_file1.c4gh"
 
@@ -178,7 +178,7 @@ else
 fi
 
 # Check listing datasets
-output=$(./sda-cli list -config testing/s3cmd-download.conf --datasets -url http://localhost:8080)
+output=$(./sda-cli -config testing/s3cmd-download.conf list --datasets -url http://localhost:8080)
 expected="https://doi.example/ty009.sfrrss/600.45asasga"
 if [[ $output == *"$expected"* ]]; then
     echo "Successfully listed datasets"
@@ -188,7 +188,7 @@ else
 fi
 
 # Download whole dataset by using the sda-download feature
-./sda-cli download -config testing/s3cmd-download.conf -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-dataset --dataset
+./sda-cli -config testing/s3cmd-download.conf download -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-dataset --dataset
 
 filepaths="download-dataset/main/subfolder/dummy_data download-dataset/main/subfolder2/dummy_data2 download-dataset/main/subfolder2/random/dummy_data3"
 
@@ -210,7 +210,7 @@ else
     echo "Failed to create a user key pair for downloading encrypted files"
     exit 1
 fi
-./sda-cli download -pubkey user_key.pub.pem -config testing/s3cmd-download.conf -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir test-download main/subfolder/dummy_data.c4gh
+./sda-cli -config testing/s3cmd-download.conf download -pubkey user_key.pub.pem -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir test-download main/subfolder/dummy_data.c4gh
 
 # check if file exists in the path
 if [ ! -f "test-download/main/subfolder/dummy_data.c4gh" ]; then
@@ -315,7 +315,7 @@ rm -r test-download
 
 # Download recursively a folder
 echo "Downloading content of folder"
-./sda-cli download -config testing/s3cmd-download.conf -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-folder --recursive main/subfolder2
+./sda-cli -config testing/s3cmd-download.conf download -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-folder --recursive main/subfolder2
 
 folderpaths="download-folder/main/subfolder2/dummy_data2 download-folder/main/subfolder2/random/dummy_data3"
 
@@ -330,7 +330,7 @@ done
 rm -r download-folder
 
 # Download file by providing the file id
-./sda-cli download -config testing/s3cmd-download.conf -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-fileid urn:neic:001-001
+./sda-cli -config testing/s3cmd-download.conf download -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-fileid urn:neic:001-001
 
 # Check if file exists in the path
 if [ ! -f "download-fileid/main/subfolder/dummy_data" ]; then
@@ -349,7 +349,7 @@ rm -r download-fileid
 
 # Download the file paths content of a text file
 echo "Downloading content of a text file"
-./sda-cli download -config testing/s3cmd-download.conf -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-from-file --from-file testing/file-list.txt
+./sda-cli -config testing/s3cmd-download.conf download -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-from-file --from-file testing/file-list.txt
 
 # Check if the content of the text file has been downloaded
 content_paths="download-from-file/main/subfolder/dummy_data download-from-file/main/subfolder2/dummy_data2"

--- a/.github/integration/tests/tests.sh
+++ b/.github/integration/tests/tests.sh
@@ -150,7 +150,7 @@ else
 fi
 
 # Download file by using the sda download service
-./sda-cli download -config testing/s3cmd-download.conf -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir test-download main/subfolder/dummy_data.c4gh
+./sda-cli -config testing/s3cmd-download.conf download -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir test-download main/subfolder/dummy_data.c4gh
 
 # Check if file exists in the path
 if [ ! -f "test-download/main/subfolder/dummy_data" ]; then
@@ -168,7 +168,7 @@ fi
 rm -r test-download
 
 # Check listing files in a dataset
-output=$(./sda-cli list -config testing/s3cmd-download.conf -dataset https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080)
+output=$(./sda-cli -config testing/s3cmd-download.conf list -dataset https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080)
 expected="FileIDSizePathurn:neic:001-0011.0MB5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8_elixir-europe.org/main/subfolder/dummy_data.c4ghurn:neic:001-0021.0MB5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8_elixir-europe.org/main/subfolder2/dummy_data2.c4ghurn:neic:001-0031.0MB5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8_elixir-europe.org/main/subfolder2/random/dummy_data3.c4ghDatasetsize:3.1MB"
 if [[ "${output//[$' \t\n\r']/}" == "${expected//[$' \t\n\r']/}" ]];  then
     echo "Successfully listed files in dataset"

--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ The Priority order for the access token is:
 Now that the configuration file is downloaded, the file(s) can be uploaded to the archive using the binary file created in the first step of this guide. To upload a specific file, use the following command:
 
 ```bash
-./sda-cli upload -config <configuration_file> <encrypted_file_to_upload>
+./sda-cli -config <configuration_file> upload <encrypted_file_to_upload>
 ```
 
 where `<configuration_file>` the file downloaded in the previous step and `<encrypted_file_to_upload>` a file encrypted in the earlier steps. The tool also allows for uploading multiple files at once, by listing them separated with space like:
 
 ```bash
-./sda-cli upload -config <configuration_file> <encrypted_file_1_to_upload> <encrypted_file_2_to_upload>
+./sda-cli -config <configuration_file> upload <encrypted_file_1_to_upload> <encrypted_file_2_to_upload>
 ```
 
 Note that the files will be uploaded in the base folder of the user.
@@ -123,7 +123,7 @@ Note that the files will be uploaded in the base folder of the user.
 One can also upload entire directories recursively, i.e. including all contained files and folders while keeping the local folder structure. This can be achieved with the `-r` flag, e.g. running:
 
 ```bash
-./sda-cli upload -config <configuration_file> -r <folder_to_upload>
+./sda-cli -config <configuration_file> upload -r <folder_to_upload>
 ```
 
 will upload `<folder_to_upload>` as is, i.e. with the same inner folder and file structure as the local one, to the archive.
@@ -131,7 +131,7 @@ will upload `<folder_to_upload>` as is, i.e. with the same inner folder and file
 It is also possible to specify multiple directories and files for upload with the same command. For example,
 
 ```bash
-./sda-cli upload -config <configuration_file> -r <encrypted_file_1_to_upload> <encrypted_file_2_to_upload> <folder_1_to_upload> <folder_2_to_upload>
+./sda-cli -config <configuration_file> upload -r <encrypted_file_1_to_upload> <encrypted_file_2_to_upload> <folder_1_to_upload> <folder_2_to_upload>
 ```
 
 However, if `-r` is omitted in the above, any folders will be skipped during upload.
@@ -141,7 +141,7 @@ However, if `-r` is omitted in the above, any folders will be skipped during upl
 The user can specify a different path for uploading files/folders with the `-targetDir` flag followed by the name of the folder. For example, the command:
 
 ```bash
-./sda-cli upload -config <configuration_file> -r <encrypted_file_1_to_upload> <folder_1_to_upload> -targetDir <upload_folder>
+./sda-cli -config <configuration_file> upload -r <encrypted_file_1_to_upload> <folder_1_to_upload> -targetDir <upload_folder>
 ```
 
 will create `<upload_folder>` under the user's base folder with contents `<upload_folder>/<encrypted_file_1_to_upload>` and `<upload_folder>/<folder_1_to_upload>`. Note that the given `<upload_folder>` may well be a folder path, e.g. `<folder1/folder2>`, and in this case `<encrypted_file_1_to_upload>` will be uploaded to `folder1/folder2/<encrypted_file_1_to_upload>`.
@@ -149,7 +149,7 @@ will create `<upload_folder>` under the user's base folder with contents `<uploa
 As a side note it is possible to include all the contents of a directory with `/.`, for example,
 
 ```bash
-./sda-cli upload -config <configuration_file> -r <folder_to_upload>/. -targetDir <new_folder_name>
+./sda-cli -config <configuration_file> upload -r <folder_to_upload>/. -targetDir <new_folder_name>
 ```
 
 will upload all contents of `<folder_to_upload>` to `<new_folder_name>` recursively, effectively renaming `<folder_to_upload>` upon upload to the archive.
@@ -159,7 +159,7 @@ will upload all contents of `<folder_to_upload>` to `<new_folder_name>` recursiv
 It is possible to combine the encryption and upload steps with the use of the flag `--encrypt-with-key` followed by the path of the crypt4gh public key to be used for encryption. In this case, the input list of file arguments can only contain _unencrypted_ source files. For example the following,
 
 ```bash
-./sda-cli upload -config <configuration_file> --encrypt-with-key <public_key> <unencrypted_file_to_upload>
+./sda-cli -config <configuration_file> upload --encrypt-with-key <public_key> <unencrypted_file_to_upload>
 ```
 
 will encrypt `<unencrypted_file_to_upload>` using `<public_key>` as public key and upload the created `<file_to_upload.c4gh>` in the base folder of the user.
@@ -167,7 +167,7 @@ will encrypt `<unencrypted_file_to_upload>` using `<public_key>` as public key a
 Encrypt on upload can be combined with any of the flags above. For example,
 
 ```bash
-./sda-cli upload -config <configuration_file> --encrypt-with-key <public_key> -r <folder_to_upload_with_unencrypted_data> -targetDir <new_folder_name>
+./sda-cli -config <configuration_file> upload --encrypt-with-key <public_key> -r <folder_to_upload_with_unencrypted_data> -targetDir <new_folder_name>
 ```
 
 will first encrypt all files in `<folder_to_upload_with_unencrypted_data>` and then upload the folder recursively (selecting only the created `c4gh` files) under `<new_folder_name>`.
@@ -190,13 +190,13 @@ All the following cases require a [configuration file to be downloaded](https://
 This feature returns all the files in the user's inbox recursively and can be executed using:
 
 ```bash
-./sda-cli list [-config <configuration_file>]
+./sda-cli [-config <configuration_file>] list
 ```
 
 It also allows for requesting files/filepaths with a specified prefix using:
 
 ```bash
-./sda-cli list [-config <configuration_file>] <prefix>
+./sda-cli [-config <configuration_file>] list <prefix>
 ```
 
 This command will return any file/path starting with the defined `<prefix>`.
@@ -207,7 +207,7 @@ If no config is given by the user, the tool will look for a previous login from 
 To list datasets or the files within a dataset that the user has access to, the `--datasets` flag should be used and the login URL must be provided:
 
 ```bash
-./sda-cli list -config <configuration_file> --datasets --url <login_url> (--bytes)
+./sda-cli -config <configuration_file> list --datasets --url <login_url> (--bytes)
 ```
 
 where `<login_url>` is the URL where the user goes for authentication. This command returns a list of accessible datasets, including the number
@@ -216,7 +216,7 @@ of files in each dataset and the total size of it. The `--bytes` flag is optiona
 To list the files within a particular dataset, the user must provide the dataset ID (which can be obtained by executing the previous command):
 
 ```bash
-./sda-cli list -config <configuration_file> -dataset <datasetID> -url <login_url> (--bytes)
+./sda-cli -config <configuration_file> list -dataset <datasetID> -url <login_url> (--bytes)
 ```
 
 This command returns a list of files within the dataset, including their file IDs, file sizes and file paths. The `--bytes` flag is optional and it will display the size of the files in bytes.
@@ -241,14 +241,14 @@ For downloading files the user also needs to know the download service URL and t
 For downloading one specific file the user needs to provide the path or the id (the id should **NOT** have "/") of this file by running the command below:
 
 ```bash
-./sda-cli download -config <configuration_file> -dataset-id <datasetID> -url <download-service-URL> [<filepath> or <fileid>]
+./sda-cli -config <configuration_file> download -dataset-id <datasetID> -url <download-service-URL> [<filepath> or <fileid>]
 ```
 
 where `<configuration_file>` the file downloaded in the [previous step](#download-the-configuration-file), `<dataset_id>` the ID of the dataset and `<filepath>` the path of the file (or `<fileid>` the id of the file) in the dataset.
 The tool also allows for downloading multiple files at once, by listing their filepaths (or file ids) separated with space and it also allows for selecting a folder where the files will be downloaded, using the `outdir` argument:
 
 ```bash
-./sda-cli download -config <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> <path/to/file1> <other/path/to/file2> ... (or <fileID_1> <fileID_2> ...)
+./sda-cli -config download <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> <path/to/file1> <other/path/to/file2> ... (or <fileID_1> <fileID_2> ...)
 ```
 
 #### Download files recursively
@@ -256,7 +256,7 @@ The tool also allows for downloading multiple files at once, by listing their fi
 For downloading the content of a folder (including subfolders) the user need to add the `--recursive` flag followed by the path(s) of the folder(s):
 
 ```bash
-./sda-cli download -config <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> --recursive path/to/folder1 path/to/folder2 ...
+./sda-cli -config download <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> --recursive path/to/folder1 path/to/folder2 ...
 ```
 
 #### Download from file
@@ -265,7 +265,7 @@ For downloading multiple files the user can provide a text file with the paths o
 In this case user needs to use the `--from-file` flag and at the end user needs to provide the path of the text file with the paths of the files to download:
 
 ```bash
-./sda-cli download -config <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> --from-file <path/to/text_file>
+./sda-cli -config download <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> --from-file <path/to/text_file>
 ```
 
 #### Download all the files of the dataset
@@ -273,7 +273,7 @@ In this case user needs to use the `--from-file` flag and at the end user needs 
 For downloading the whole dataset the user needs add the `--dataset` flag and NOT providing any filepaths:
 
 ```bash
-./sda-cli download -config <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> --dataset
+./sda-cli -config download <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> --dataset
 ```
 
 where the dataset will be downloaded in the `<outdir>` directory be keeping the original folder structure of the dataset.
@@ -283,7 +283,7 @@ where the dataset will be downloaded in the `<outdir>` directory be keeping the 
 When a [public key](#create-keys) is provided, you can download files that are encrypted on the server-side with that public key. The command is similar to downloading the unencrypted files except that a public key is provided through the `-pubkey` flag. For example:
 
 ```bash
-./sda-cli download -pubkey <public-key-file> -config <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> <filepath_1_to_download> <filepath_2_to_download> ...
+./sda-cli -config <configuration_file> download -pubkey <public-key-file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> <filepath_1_to_download> <filepath_2_to_download> ...
 ```
 
 After a successful download, the encrypted files can be [decrypted](#decrypt-file) using the private key corresponding to the provided public key.
@@ -330,7 +330,7 @@ htsget -dataset <datasetID> -filename <filename> -reference <reference-number> -
 for example:
 
 ```
-./sda-cli htsget -config testing/s3cmd.conf -dataset DATASET0001 -filename htsnexus_test_NA12878 -reference 11 -host http://localhost:8088 -pubkey testing/c4gh.pub.pem -output ~/tmp/result.c4gh --force-overwrite
+./sda-cli -config testing/s3cmd.conf htsget -dataset DATASET0001 -filename htsnexus_test_NA12878 -reference 11 -host http://localhost:8088 -pubkey testing/c4gh.pub.pem -output ~/tmp/result.c4gh --force-overwrite
 ```
 
 # Developers' section

--- a/download/download.go
+++ b/download/download.go
@@ -26,7 +26,7 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help download` command
 var Usage = `
-USAGE: %s download -config <s3config-file> -dataset-id <datasetID> -url <uri> (--pubkey <public-key-file>) (-outdir <dir>) ([filepath(s) or fileid(s)] or --dataset or --recursive <dirpath>) or --from-file <list-filepath>
+USAGE: %s -config <s3config-file> download -dataset-id <datasetID> -url <uri> (--pubkey <public-key-file>) (-outdir <dir>) ([filepath(s) or fileid(s)] or --dataset or --recursive <dirpath>) or --from-file <list-filepath>
 
 download:
 	Downloads files from the Sensitive Data Archive (SDA) by using APIs from the given url. The user
@@ -57,8 +57,6 @@ var ArgHelp = `
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help
 var Args = flag.NewFlagSet("download", flag.ExitOnError)
-
-var configPath = Args.String("config", "", "S3 config file to use for downloading.")
 
 var datasetID = Args.String("dataset-id", "", "Dataset ID for the file to download.")
 
@@ -96,17 +94,14 @@ type File struct {
 
 // Download function downloads files from the SDA by using the
 // download's service APIs
-func Download(args []string, configPathF string) error {
+func Download(args []string, configPath string) error {
 	// Call ParseArgs to take care of all the flag parsing
 	err := helpers.ParseArgs(args, Args)
 	if err != nil {
 		return fmt.Errorf("failed parsing arguments, reason: %v", err)
 	}
-	if configPathF == "" {
-		configPathF = *configPath
-	}
 
-	if *datasetID == "" || *URL == "" || configPathF == "" {
+	if *datasetID == "" || *URL == "" || configPath == "" {
 		return fmt.Errorf("missing required arguments, dataset, config and url are required")
 	}
 
@@ -139,7 +134,7 @@ func Download(args []string, configPathF string) error {
 	}
 
 	// Get the configuration file or the .sda-cli-session
-	config, err := helpers.GetAuth(configPathF)
+	config, err := helpers.GetAuth(configPath)
 	if err != nil {
 		return err
 	}

--- a/download/download.go
+++ b/download/download.go
@@ -96,14 +96,17 @@ type File struct {
 
 // Download function downloads files from the SDA by using the
 // download's service APIs
-func Download(args []string) error {
+func Download(args []string, configPathF string) error {
 	// Call ParseArgs to take care of all the flag parsing
 	err := helpers.ParseArgs(args, Args)
 	if err != nil {
 		return fmt.Errorf("failed parsing arguments, reason: %v", err)
 	}
+	if configPathF == "" {
+		configPathF = *configPath
+	}
 
-	if *datasetID == "" || *URL == "" || *configPath == "" {
+	if *datasetID == "" || *URL == "" || configPathF == "" {
 		return fmt.Errorf("missing required arguments, dataset, config and url are required")
 	}
 
@@ -136,7 +139,7 @@ func Download(args []string) error {
 	}
 
 	// Get the configuration file or the .sda-cli-session
-	config, err := helpers.GetAuth(*configPath)
+	config, err := helpers.GetAuth(configPathF)
 	if err != nil {
 		return err
 	}

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -76,7 +76,7 @@ func (suite *TestSuite) TestInvalidUrl() {
 		"file2",
 	}
 
-	err := Download(os.Args)
+	err := Download(os.Args, "")
 	assert.Contains(
 		suite.T(),
 		err.Error(),

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -68,15 +68,13 @@ func (suite *TestSuite) TestInvalidUrl() {
 		"download",
 		"-dataset-id",
 		"TES01",
-		"-config",
-		confPath.Name(),
 		"-url",
 		"https://some/url",
 		"file1",
 		"file2",
 	}
 
-	err := Download(os.Args, "")
+	err := Download(os.Args, confPath.Name())
 	assert.Contains(
 		suite.T(),
 		err.Error(),

--- a/htsget/htsget.go
+++ b/htsget/htsget.go
@@ -20,7 +20,7 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help htsget` command
 var Usage = `
-USAGE: %s htsget [-dataset <datasetID>] [-filename <filename>] (-reference <referenceName>) [-htsgethost <htsget-hostname>] [-pubkey <public-key-file>] (-output <file>) (--force-overwrite)
+USAGE: %s -config testing/s3cmd.conf htsget [-dataset <datasetID>] [-filename <filename>] (-reference <referenceName>) [-htsgethost <htsget-hostname>] [-pubkey <public-key-file>] (-output <file>) (--force-overwrite)
 
 htsget:
 	Htsget downloads files from the Sensitive Data Archive (SDA), using the
@@ -51,7 +51,6 @@ var fileName = Args.String("filename", "", "The name of the file to download")
 var referenceName = Args.String("reference", "", "The reference number of the file to download")
 var htsgetHost = Args.String("host", "", "The host to download from")
 var publicKeyFile = Args.String("pubkey", "", "Public key file")
-var configPath = Args.String("config", "", "config file.")
 var outPut = Args.String("output", "", "Name for the downloaded file.")
 var forceOverwrite = Args.Bool("force-overwrite", false, "Force overwrite existing files.")
 
@@ -73,22 +72,19 @@ type htsgetResponse struct {
 
 // Htsget function downloads the files included in the urls_list.txt file.
 // The argument can be a local file or a url to an S3 folder
-func Htsget(args []string, configPathF string) error {
+func Htsget(args []string, configPath string) error {
 
 	// Call ParseArgs to take care of all the flag parsing
 	err := helpers.ParseArgs(args, Args)
 	if err != nil {
 		return fmt.Errorf("failed parsing arguments, reason: %v", err)
 	}
-	if configPathF == "" {
-		configPathF = *configPath
-	}
 
 	if *datasetID == "" || *fileName == "" || *htsgetHost == "" || *publicKeyFile == "" {
 		return fmt.Errorf("missing required arguments, dataset, filename, host and key are required")
 	}
 
-	config, err := helpers.GetAuth(configPathF)
+	config, err := helpers.GetAuth(configPath)
 	if err != nil {
 		return err
 	}

--- a/htsget/htsget.go
+++ b/htsget/htsget.go
@@ -73,19 +73,22 @@ type htsgetResponse struct {
 
 // Htsget function downloads the files included in the urls_list.txt file.
 // The argument can be a local file or a url to an S3 folder
-func Htsget(args []string) error {
+func Htsget(args []string, configPathF string) error {
 
 	// Call ParseArgs to take care of all the flag parsing
 	err := helpers.ParseArgs(args, Args)
 	if err != nil {
 		return fmt.Errorf("failed parsing arguments, reason: %v", err)
 	}
+	if configPathF == "" {
+		configPathF = *configPath
+	}
 
 	if *datasetID == "" || *fileName == "" || *htsgetHost == "" || *publicKeyFile == "" {
 		return fmt.Errorf("missing required arguments, dataset, filename, host and key are required")
 	}
 
-	config, err := helpers.GetAuth(*configPath)
+	config, err := helpers.GetAuth(configPathF)
 	if err != nil {
 		return err
 	}

--- a/htsget/htsget_test.go
+++ b/htsget/htsget_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -54,12 +55,12 @@ multipart_chunk_size_mb = 50
 use_https = False
 socket_timeout = 30
 access_token = eyJ0eXAiOiJKV1QiLCJqa3UiOiJodHRwczovL29pZGM6ODA4MC9qd2siLCJhbGciOiJFUzI1NiIsImtpZCI6IlYxcXN1VlVINUEyaTR5TWlmSFZTQWJDTTlxMnVldkF0MUktNzZfdlNTVjQifQ.eyJzdWIiOiJyZXF1ZXN0ZXJAZGVtby5vcmciLCJhdWQiOlsiYXVkMSIsImF1ZDIiXSwiYXpwIjoiYXpwIiwic2NvcGUiOiJvcGVuaWQgZ2E0Z2hfcGFzc3BvcnRfdjEiLCJpc3MiOiJodHRwczovL29pZGM6ODA4MC8iLCJleHAiOjk5OTk5OTk5OTksImlhdCI6MTU2MTYyMTkxMywianRpIjoiNmFkN2FhNDItM2U5Yy00ODMzLWJkMTYtNzY1Y2I4MGMyMTAyIn0.shY1Af3m6cPbRQd5Rn_tjvzBiJ8zx0cbsPkV8nebGrqAekpp42kUuoTYc2GCekowZMx-7J_qt3pz5Tk6nRyIHw`
-	err := os.WriteFile(tmpDir+"s3cmd_test.conf", []byte(s3cmdConf), 0600)
+	err := os.WriteFile(filepath.Join(tmpDir, "s3cmd_test.conf"), []byte(s3cmdConf), 0600)
 	if err != nil {
 		panic(err)
 	}
 	os.Args = []string{"htsget", "-dataset", "DATASET0001", "-filename", "htsnexus_test_NA12878", "-host", "somehost", "-pubkey", "somekey"}
-	err = Htsget(os.Args, tmpDir+"s3cmd_test.conf")
+	err = Htsget(os.Args, filepath.Join(tmpDir, "s3cmd_test.conf"))
 	assert.ErrorContains(suite.T(), err, "failed to read public key")
 }
 
@@ -79,7 +80,7 @@ multipart_chunk_size_mb = 50
 use_https = False
 socket_timeout = 30
 access_token = eyJ0eXAiOiJKV1QiLCJqa3UiOiJodHRwczovL29pZGM6ODA4MC9qd2siLCJhbGciOiJFUzI1NiIsImtpZCI6IlYxcXN1VlVINUEyaTR5TWlmSFZTQWJDTTlxMnVldkF0MUktNzZfdlNTVjQifQ.eyJzdWIiOiJyZXF1ZXN0ZXJAZGVtby5vcmciLCJhdWQiOlsiYXVkMSIsImF1ZDIiXSwiYXpwIjoiYXpwIiwic2NvcGUiOiJvcGVuaWQgZ2E0Z2hfcGFzc3BvcnRfdjEiLCJpc3MiOiJodHRwczovL29pZGM6ODA4MC8iLCJleHAiOjk5OTk5OTk5OTksImlhdCI6MTU2MTYyMTkxMywianRpIjoiNmFkN2FhNDItM2U5Yy00ODMzLWJkMTYtNzY1Y2I4MGMyMTAyIn0.shY1Af3m6cPbRQd5Rn_tjvzBiJ8zx0cbsPkV8nebGrqAekpp42kUuoTYc2GCekowZMx-7J_qt3pz5Tk6nRyIHw`
-	err := os.WriteFile(tmpDir+"s3cmd_test.conf", []byte(s3cmdConf), 0600)
+	err := os.WriteFile(filepath.Join(tmpDir, "s3cmd_test.conf"), []byte(s3cmdConf), 0600)
 	if err != nil {
 		panic(err)
 	}
@@ -91,7 +92,7 @@ KKj6NUcJGZ2/HeqkYbxm57ZaFLP5cIHsdK+0nQubFVs=
 		panic(err)
 	}
 	os.Args = []string{"htsget", "-dataset", "DATASET0001", "-filename", "htsnexus_test_NA12878", "-host", "missingserver", "-pubkey", tmpDir + "c4gh.pub.pem"}
-	err = Htsget(os.Args, tmpDir+"s3cmd_test.conf")
+	err = Htsget(os.Args, filepath.Join(tmpDir, "s3cmd_test.conf"))
 	assert.ErrorContains(suite.T(), err, "failed to do the request")
 }
 
@@ -112,7 +113,7 @@ multipart_chunk_size_mb = 50
 use_https = False
 socket_timeout = 30
 access_token = eyJ0eXAiOiJKV1QiLCJqa3UiOiJodHRwczovL29pZGM6ODA4MC9qd2siLCJhbGciOiJFUzI1NiIsImtpZCI6IlYxcXN1VlVINUEyaTR5TWlmSFZTQWJDTTlxMnVldkF0MUktNzZfdlNTVjQifQ.eyJzdWIiOiJyZXF1ZXN0ZXJAZGVtby5vcmciLCJhdWQiOlsiYXVkMSIsImF1ZDIiXSwiYXpwIjoiYXpwIiwic2NvcGUiOiJvcGVuaWQgZ2E0Z2hfcGFzc3BvcnRfdjEiLCJpc3MiOiJodHRwczovL29pZGM6ODA4MC8iLCJleHAiOjk5OTk5OTk5OTksImlhdCI6MTU2MTYyMTkxMywianRpIjoiNmFkN2FhNDItM2U5Yy00ODMzLWJkMTYtNzY1Y2I4MGMyMTAyIn0.shY1Af3m6cPbRQd5Rn_tjvzBiJ8zx0cbsPkV8nebGrqAekpp42kUuoTYc2GCekowZMx-7J_qt3pz5Tk6nRyIHw`
-	err := os.WriteFile(tmpDir+"s3cmd_test.conf", []byte(s3cmdConf), 0600)
+	err := os.WriteFile(filepath.Join(tmpDir, "s3cmd_test.conf"), []byte(s3cmdConf), 0600)
 	if err != nil {
 		panic(err)
 	}
@@ -185,6 +186,6 @@ KKj6NUcJGZ2/HeqkYbxm57ZaFLP5cIHsdK+0nQubFVs=
 	defer server.Close()
 
 	os.Args = []string{"htsget", "-dataset", "DATASET0001", "-filename", "htsnexus_test_NA12878", "-host", server.URL, "-pubkey", tmpDir + "c4gh.pub.pem"}
-	err = Htsget(os.Args, tmpDir+"s3cmd_test.conf")
+	err = Htsget(os.Args, filepath.Join(tmpDir, "s3cmd_test.conf"))
 	assert.ErrorContains(suite.T(), err, "error downloading the files")
 }

--- a/htsget/htsget_test.go
+++ b/htsget/htsget_test.go
@@ -22,7 +22,7 @@ func TestConfigTestSuite(t *testing.T) {
 func (suite *TestSuite) MissingArgument() {
 
 	os.Args = []string{"htsget"}
-	err := Htsget(os.Args)
+	err := Htsget(os.Args, "")
 	assert.EqualError(suite.T(), err, "missing required arguments, dataset, filename, host and key are required")
 }
 
@@ -30,7 +30,7 @@ func (suite *TestSuite) MissingArgument() {
 
 func (suite *TestSuite) TestHtsgetMissingConfig() {
 	os.Args = []string{"htsget", "-config", "nonexistent.conf", "-dataset", "DATASET0001", "-filename", "htsnexus_test_NA12878", "-host", "somehost", "-pubkey", "somekey"}
-	err := Htsget(os.Args)
+	err := Htsget(os.Args, "")
 	msg := "no such file or directory"
 	if runtime.GOOS == "windows" {
 		msg = "open nonexistent.conf: The system cannot find the file specified."
@@ -59,7 +59,7 @@ access_token = eyJ0eXAiOiJKV1QiLCJqa3UiOiJodHRwczovL29pZGM6ODA4MC9qd2siLCJhbGciO
 		panic(err)
 	}
 	os.Args = []string{"htsget", "-config", tmpDir + "s3cmd_test.conf", "-dataset", "DATASET0001", "-filename", "htsnexus_test_NA12878", "-host", "somehost", "-pubkey", "somekey"}
-	err = Htsget(os.Args)
+	err = Htsget(os.Args, "")
 	assert.ErrorContains(suite.T(), err, "failed to read public key")
 }
 
@@ -91,7 +91,7 @@ KKj6NUcJGZ2/HeqkYbxm57ZaFLP5cIHsdK+0nQubFVs=
 		panic(err)
 	}
 	os.Args = []string{"htsget", "-config", tmpDir + "s3cmd_test.conf", "-dataset", "DATASET0001", "-filename", "htsnexus_test_NA12878", "-host", "missingserver", "-pubkey", tmpDir + "c4gh.pub.pem"}
-	err = Htsget(os.Args)
+	err = Htsget(os.Args, "")
 	assert.ErrorContains(suite.T(), err, "failed to do the request")
 }
 
@@ -185,6 +185,6 @@ KKj6NUcJGZ2/HeqkYbxm57ZaFLP5cIHsdK+0nQubFVs=
 	defer server.Close()
 
 	os.Args = []string{"htsget", "-config", tmpDir + "s3cmd_test.conf", "-dataset", "DATASET0001", "-filename", "htsnexus_test_NA12878", "-host", server.URL, "-pubkey", tmpDir + "c4gh.pub.pem"}
-	err = Htsget(os.Args)
+	err = Htsget(os.Args, "")
 	assert.ErrorContains(suite.T(), err, "error downloading the files")
 }

--- a/htsget/htsget_test.go
+++ b/htsget/htsget_test.go
@@ -29,8 +29,8 @@ func (suite *TestSuite) MissingArgument() {
 // test Htsget with mocked http request
 
 func (suite *TestSuite) TestHtsgetMissingConfig() {
-	os.Args = []string{"htsget", "-config", "nonexistent.conf", "-dataset", "DATASET0001", "-filename", "htsnexus_test_NA12878", "-host", "somehost", "-pubkey", "somekey"}
-	err := Htsget(os.Args, "")
+	os.Args = []string{"htsget", "-dataset", "DATASET0001", "-filename", "htsnexus_test_NA12878", "-host", "somehost", "-pubkey", "somekey"}
+	err := Htsget(os.Args, "nonexistent.conf")
 	msg := "no such file or directory"
 	if runtime.GOOS == "windows" {
 		msg = "open nonexistent.conf: The system cannot find the file specified."
@@ -58,8 +58,8 @@ access_token = eyJ0eXAiOiJKV1QiLCJqa3UiOiJodHRwczovL29pZGM6ODA4MC9qd2siLCJhbGciO
 	if err != nil {
 		panic(err)
 	}
-	os.Args = []string{"htsget", "-config", tmpDir + "s3cmd_test.conf", "-dataset", "DATASET0001", "-filename", "htsnexus_test_NA12878", "-host", "somehost", "-pubkey", "somekey"}
-	err = Htsget(os.Args, "")
+	os.Args = []string{"htsget", "-dataset", "DATASET0001", "-filename", "htsnexus_test_NA12878", "-host", "somehost", "-pubkey", "somekey"}
+	err = Htsget(os.Args, tmpDir+"s3cmd_test.conf")
 	assert.ErrorContains(suite.T(), err, "failed to read public key")
 }
 
@@ -90,8 +90,8 @@ KKj6NUcJGZ2/HeqkYbxm57ZaFLP5cIHsdK+0nQubFVs=
 	if err != nil {
 		panic(err)
 	}
-	os.Args = []string{"htsget", "-config", tmpDir + "s3cmd_test.conf", "-dataset", "DATASET0001", "-filename", "htsnexus_test_NA12878", "-host", "missingserver", "-pubkey", tmpDir + "c4gh.pub.pem"}
-	err = Htsget(os.Args, "")
+	os.Args = []string{"htsget", "-dataset", "DATASET0001", "-filename", "htsnexus_test_NA12878", "-host", "missingserver", "-pubkey", tmpDir + "c4gh.pub.pem"}
+	err = Htsget(os.Args, tmpDir+"s3cmd_test.conf")
 	assert.ErrorContains(suite.T(), err, "failed to do the request")
 }
 
@@ -184,7 +184,7 @@ KKj6NUcJGZ2/HeqkYbxm57ZaFLP5cIHsdK+0nQubFVs=
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	os.Args = []string{"htsget", "-config", tmpDir + "s3cmd_test.conf", "-dataset", "DATASET0001", "-filename", "htsnexus_test_NA12878", "-host", server.URL, "-pubkey", tmpDir + "c4gh.pub.pem"}
-	err = Htsget(os.Args, "")
+	os.Args = []string{"htsget", "-dataset", "DATASET0001", "-filename", "htsnexus_test_NA12878", "-host", server.URL, "-pubkey", tmpDir + "c4gh.pub.pem"}
+	err = Htsget(os.Args, tmpDir+"s3cmd_test.conf")
 	assert.ErrorContains(suite.T(), err, "error downloading the files")
 }

--- a/list/list.go
+++ b/list/list.go
@@ -18,7 +18,7 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help list` command
 var Usage = `
-USAGE: %s list [-config <s3config-file>] [prefix] (-url <uri> --datasets) (-url <uri> --dataset <dataset-id>) [-bytes]
+USAGE: %s [-config <s3config-file>] list [prefix] (-url <uri> --datasets) (-url <uri> --dataset <dataset-id>) [-bytes]
 
 list:
     Lists recursively all files under the user's folder in the Sensitive
@@ -40,9 +40,6 @@ var ArgHelp = `
 // main program help
 var Args = flag.NewFlagSet("list", flag.ExitOnError)
 
-var configPath = Args.String("config", "",
-	"S3 config file to use for listing.")
-
 var URL = Args.String("url", "", "The url of the sda-download server")
 
 var datasets = Args.Bool("datasets", false, "List all datasets in the user's folder.")
@@ -52,14 +49,11 @@ var bytesFormat = Args.Bool("bytes", false, "Print file sizes in bytes (not huma
 var dataset = Args.String("dataset", "", "List all files in the specified dataset.")
 
 // List function lists the contents of an s3
-func List(args []string, configPathF string) error {
+func List(args []string, configPath string) error {
 	// Call ParseArgs to take care of all the flag parsing
 	err := helpers.ParseArgs(args, Args)
 	if err != nil {
 		return fmt.Errorf("failed parsing arguments, reason: %v", err)
-	}
-	if configPathF == "" {
-		configPathF = *configPath
 	}
 
 	prefix := ""
@@ -68,7 +62,7 @@ func List(args []string, configPathF string) error {
 	}
 
 	// // Get the configuration file or the .sda-cli-session
-	config, err := helpers.GetAuth(configPathF)
+	config, err := helpers.GetAuth(configPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config file, reason: %v", err)
 	}

--- a/list/list.go
+++ b/list/list.go
@@ -52,11 +52,14 @@ var bytesFormat = Args.Bool("bytes", false, "Print file sizes in bytes (not huma
 var dataset = Args.String("dataset", "", "List all files in the specified dataset.")
 
 // List function lists the contents of an s3
-func List(args []string) error {
+func List(args []string, configPathF string) error {
 	// Call ParseArgs to take care of all the flag parsing
 	err := helpers.ParseArgs(args, Args)
 	if err != nil {
 		return fmt.Errorf("failed parsing arguments, reason: %v", err)
+	}
+	if configPathF == "" {
+		configPathF = *configPath
 	}
 
 	prefix := ""
@@ -65,7 +68,7 @@ func List(args []string) error {
 	}
 
 	// // Get the configuration file or the .sda-cli-session
-	config, err := helpers.GetAuth(*configPath)
+	config, err := helpers.GetAuth(configPathF)
 	if err != nil {
 		return fmt.Errorf("failed to load config file, reason: %v", err)
 	}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -37,7 +37,7 @@ func (suite *TestSuite) SetupTest() {
 
 func (suite *TestSuite) TestNoConfig() {
 
-	os.Args = []string{"list", "-config", ""}
+	os.Args = []string{"list"}
 
 	err := List(os.Args, "")
 	assert.EqualError(suite.T(), err, "failed to load config file, reason: failed to read the configuration file")
@@ -126,8 +126,8 @@ func (suite *TestSuite) TestFunctionality() {
 	log.SetOutput(&uploadOutput)
 
 	// Upload a file
-	os.Args = []string{"upload", "--force-unencrypted", "-config", configPath.Name(), "-r", dir}
-	err = upload.Upload(os.Args, "")
+	os.Args = []string{"upload", "--force-unencrypted", "-r", dir}
+	err = upload.Upload(os.Args, configPath.Name())
 	assert.NoError(suite.T(), err)
 
 	// Check logs that file was uploaded
@@ -141,8 +141,8 @@ func (suite *TestSuite) TestFunctionality() {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	os.Args = []string{"list", "-config", configPath.Name()}
-	err = List(os.Args, "")
+	os.Args = []string{"list"}
+	err = List(os.Args, configPath.Name())
 	assert.NoError(suite.T(), err)
 
 	w.Close()

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -39,7 +39,7 @@ func (suite *TestSuite) TestNoConfig() {
 
 	os.Args = []string{"list", "-config", ""}
 
-	err := List(os.Args)
+	err := List(os.Args, "")
 	assert.EqualError(suite.T(), err, "failed to load config file, reason: failed to read the configuration file")
 }
 
@@ -127,7 +127,7 @@ func (suite *TestSuite) TestFunctionality() {
 
 	// Upload a file
 	os.Args = []string{"upload", "--force-unencrypted", "-config", configPath.Name(), "-r", dir}
-	err = upload.Upload(os.Args)
+	err = upload.Upload(os.Args, "")
 	assert.NoError(suite.T(), err)
 
 	// Check logs that file was uploaded
@@ -142,7 +142,7 @@ func (suite *TestSuite) TestFunctionality() {
 	os.Stdout = w
 
 	os.Args = []string{"list", "-config", configPath.Name()}
-	err = List(os.Args)
+	err = List(os.Args, "")
 	assert.NoError(suite.T(), err)
 
 	w.Close()

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ var Commands = map[string]commandInfo{
 func main() {
 
 	log.SetLevel(log.WarnLevel)
-	command, args := ParseArgs()
+	command, args, configPath := ParseArgs()
 
 	var err error
 
@@ -61,15 +61,15 @@ func main() {
 	case "decrypt":
 		err = decrypt.Decrypt(args)
 	case "upload":
-		err = upload.Upload(args)
+		err = upload.Upload(args, configPath)
 	case "list":
-		err = list.List(args)
+		err = list.List(args, configPath)
 	case "htsget":
-		err = htsget.Htsget(args)
+		err = htsget.Htsget(args, configPath)
 	case "login":
 		err = login.NewLogin(args)
 	case "download":
-		err = download.Download(args)
+		err = download.Download(args, configPath)
 	case "version":
 		err = version.Version(Version)
 	default:
@@ -84,7 +84,8 @@ func main() {
 
 // Parses the command line arguments into a command, and keep the rest
 // of the arguments for the subcommand.
-func ParseArgs() (string, []string) {
+func ParseArgs() (string, []string, string) {
+	var configPath string
 	// Print usage if no arguments are provided.
 	if len(os.Args) < 2 {
 		_ = Help("help")
@@ -98,7 +99,18 @@ func ParseArgs() (string, []string) {
 			os.Exit(0)
 		}
 
-		return "version", os.Args
+		return "version", os.Args, ""
+	}
+
+	// If config comes before the command, we remove it from the
+	// arguments and set the global config path.
+	if len(os.Args) > 1 && (os.Args[1] == "--config" || os.Args[1] == "-config") {
+		if len(os.Args) < 3 {
+			fmt.Fprintf(os.Stderr, "Error: --config requires an argument\n")
+			os.Exit(1)
+		}
+		configPath = os.Args[2]
+		os.Args = append(os.Args[:1], os.Args[3:]...)
 	}
 
 	// Extract the command from the 1st argument, then remove it
@@ -130,7 +142,7 @@ func ParseArgs() (string, []string) {
 	// The "list" command can have no arguments since it can use the
 	// config from login so we immediately return in that case.
 	if command == "list" {
-		return command, os.Args
+		return command, os.Args, configPath
 	}
 
 	// If no arguments are provided to the subcommand, it's not
@@ -141,7 +153,7 @@ func ParseArgs() (string, []string) {
 		os.Exit(1)
 	}
 
-	return command, os.Args
+	return command, os.Args, configPath
 }
 
 // Prints the main usage string, and the global help or command help

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 
 var Version = "development"
 
-var Usage = `USAGE: %s <command> [command-args]
+var Usage = `USAGE: %s -config <s3config-file> <command> [command-args]
 
 This is a helper tool that can help with common tasks when interacting
 with the Sensitive Data Archive (SDA).

--- a/main.go
+++ b/main.go
@@ -100,11 +100,7 @@ func ParseArgs() (string, []string, string) {
 		}
 
 		return "version", os.Args, ""
-	}
-
-	// If config comes before the command, we remove it from the
-	// arguments and set the global config path.
-	if len(os.Args) > 1 && (os.Args[1] == "--config" || os.Args[1] == "-config") {
+	case "--config", "-config":
 		if len(os.Args) < 3 {
 			fmt.Fprintf(os.Stderr, "Error: --config requires an argument\n")
 			os.Exit(1)

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -256,7 +256,7 @@ func createFilePaths(dirPath string) ([]string, []string, error) {
 
 // Upload function uploads files to the s3 bucket. Input can be files or
 // directories to be uploaded recursively
-func Upload(args []string) error {
+func Upload(args []string, configPathF string) error {
 	var files []string
 	var outFiles []string
 	*pubKeyPath = ""
@@ -266,6 +266,9 @@ func Upload(args []string) error {
 	err := helpers.ParseArgs(args, Args)
 	if err != nil {
 		return fmt.Errorf("failed parsing arguments, reason: %v", err)
+	}
+	if configPathF == "" {
+		configPathF = *configPath
 	}
 
 	// Dereference the pointer to a string
@@ -288,7 +291,7 @@ func Upload(args []string) error {
 	}
 
 	// Get the configuration file or the .sda-cli-session
-	config, err := helpers.GetAuth(*configPath)
+	config, err := helpers.GetAuth(configPathF)
 	if err != nil {
 		return err
 	}

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -63,7 +63,7 @@ var pubKeyPath = Args.String("encrypt-with-key", "",
 var accessToken = Args.String("accessToken", "", "Access token to the inbox service.\n(optional, if it is set in the config file or exported as the ENV `ACCESSTOKEN`)")
 
 // Function uploadFiles uploads the files in the input list to the s3 bucket
-func uploadFiles(files, outFiles []string, targetDir string, config *helpers.Config, configPath string) error {
+func uploadFiles(files, outFiles []string, targetDir string, config *helpers.Config) error {
 	// check also here in case sth went wrong with input files
 	if len(files) == 0 {
 		return errors.New("no files to upload")
@@ -123,8 +123,6 @@ func uploadFiles(files, outFiles []string, targetDir string, config *helpers.Con
 
 		// create progress bar instance
 		p := mpb.New()
-		log.Infof("Uploading %s with config %s\n", filename, configPath)
-		fmt.Printf("Uploading %s with config %s\n", filename, configPath)
 
 		f, err := os.Open(path.Clean(filename))
 		if err != nil {
@@ -362,5 +360,5 @@ func Upload(args []string, configPath string) error {
 		}
 	}
 
-	return uploadFiles(files, outFiles, filepath.ToSlash(*targetDir), config, configPath)
+	return uploadFiles(files, outFiles, filepath.ToSlash(*targetDir), config)
 }

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -98,7 +98,7 @@ func (suite *TestSuite) TestSampleNoFiles() {
 	config, _ := helpers.LoadConfigFile(configPath.Name())
 	var files []string
 
-	err = uploadFiles(files, files, "", config, configPath.Name())
+	err = uploadFiles(files, files, "", config)
 	assert.EqualError(suite.T(), err, "no files to upload")
 }
 


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #442 .


**Description**
The user should be able to provide the config file location argument *ONLY* before the subcommand of the cli. 

**How to test**
For test coverage, some of the existing tests have been altered to follow the new allowed order of providing the config, i.e. before the subcommand.
To manually test, one should test individually the cli commands that are affected. Those are the ones that are using the config as an argument(upload, list htsget, download).