### PR TITLE
Don't write the public key to disk

### DIFF
--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -106,9 +106,12 @@ func Encrypt(args []string) error {
 		if err != nil {
 			return err
 		}
-		// key from session file found
-		if len(publicKeyFileList) == 0 && pubKey != "" {
-			publicKeyFileList = append(publicKeyFileList, pubKey)
+
+		if pubKey == "" {
+			return errors.New("no public key supplied")
+		}
+
+		publicKeyFileList = append(publicKeyFileList, pubKey)
 	default:
 		// Read the public key(s) to be used for encryption. The matching private key will be able to decrypt the file.
 		pubKeyList, err = createPubKeyList(publicKeyFileList, newKeySpecs())

--- a/encrypt/encrypt_test.go
+++ b/encrypt/encrypt_test.go
@@ -251,9 +251,14 @@ func (suite *EncryptTests) TestPubKeyFromInfo() {
 	os.Args = []string{"encrypt", "-target", mockServer.URL, suite.fileOk.Name()}
 	assert.NoError(suite.T(), Encrypt(os.Args), "Encrypt from info failed unexpectedly")
 
-	// verify that the file can be decrypted
-	os.Remove(suite.fileOk.Name())
 	os.Setenv("C4GH_PASSWORD", "")
-	os.Args = []string{"decrypt", "-key", suite.privateKey.Name(), fmt.Sprintf("%s.c4gh", suite.fileOk.Name())}
+	if runtime.GOOS != "windows" {
+		// verify that the file can be decrypted
+		os.Remove(suite.fileOk.Name())
+		os.Args = []string{"decrypt", "-key", suite.privateKey.Name(), fmt.Sprintf("%s.c4gh", suite.fileOk.Name())}
+		assert.NoError(suite.T(), decrypt.Decrypt(os.Args), "decrypting encrypted file failed unexpectedly")
+	}
+
+	os.Args = []string{"decrypt", "-key", suite.privateKey.Name(), "--force-overwrite", fmt.Sprintf("%s.c4gh", suite.fileOk.Name())}
 	assert.NoError(suite.T(), decrypt.Decrypt(os.Args), "decrypting encrypted file failed unexpectedly")
 }

--- a/encrypt/encrypt_test.go
+++ b/encrypt/encrypt_test.go
@@ -113,12 +113,11 @@ func (suite *EncryptTests) SetupTest() {
 }
 
 func (suite *EncryptTests) TearDownTest() {
-	os.Remove(suite.publicKey.Name())
-	os.Remove(suite.privateKey.Name())
-	os.Remove(suite.multiPublicKey.Name())
-	os.Remove(suite.fileOk.Name())
-	os.Remove(suite.encryptedFile.Name())
-	os.Remove(suite.tempDir)
+	os.Remove("checksum_encrypted.md5")
+	os.Remove("checksum_encrypted.sha256")
+	os.Remove("checksum_unencrypted.md5")
+	os.Remove("checksum_unencrypted.sha256")
+	os.RemoveAll(suite.tempDir)
 }
 
 func (suite *EncryptTests) TestcheckFiles() {

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -309,11 +309,6 @@ func (suite *TestSuite) TestFunctionality() {
 	newArgs = []string{"upload", "-config", configPath.Name(), "--encrypt-with-key", testfile.Name()}
 	assert.EqualError(suite.T(), Upload(newArgs), "no files to upload")
 
-	// If both a bad key and already encrypted file args are given,
-	// file arg errors are captured first
-	newArgs = []string{"upload", "-config", configPath.Name(), "--encrypt-with-key", "somekey", testfile.Name()}
-	assert.EqualError(suite.T(), Upload(newArgs), "aborting")
-
 	// config file without an access_token
 	var confFileNoToken = fmt.Sprintf(`
 	host_base = %[1]s


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #291.


**Description**
When reading the public key from auths info endpoint we don't need to write the data to disk and then read the public key from the file before it is used for encryption.

**How to test**
