### PR TITLE
update help info and documentation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-
-
 # personal files
 .vscode/
 personal/
@@ -9,3 +7,7 @@ sda-cli
 sda-cli.exe
 
 dist/
+
+# key files
+*.pub.pem
+*.sec.pem

--- a/README.md
+++ b/README.md
@@ -159,8 +159,7 @@ separated by spaces, as shown below:
 **Note**:
 
 - By default, files are uploaded to the user's base directory on the archive.
-- If the input contains unencrypted files, the process will exit early. To
-override this behavior, use the `-force-unencrypted` flag.
+- If the input contains unencrypted files, the process will exit early.
 
 ### Upload folders
 
@@ -411,6 +410,11 @@ After a successful download, the encrypted files will be saved to `<outdir>`,
 maintaining their original folder structure. These files can then be
 [decrypted](#decrypt-files) using the private key corresponding to the provided
 public key.
+
+**Note**: Downloading encrypted files for an entire folder recursively, similar
+*to [downloading unencrypted files](#download-files-recursively), is still not
+*supported. To download multiple encrypted files, you must specify them as
+*arguments, as shown in the example above.
 
 ## Create Crypt4GH key pair
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # SDA-CLI
 
 This is the Sensitive Data Archive (SDA) Command Line Interface (sda-cli). This
-tool was created to unify and simplify the tools needed to perform the most
+tool was created to unify and simplify the utilities required to perform the most
 common user actions in the SDA.
 
-This tool can be used to encrypt and upload data when submitting to the archive,
-and to download and decrypt with retrieving data from the archive.
+The tool can be used to encrypt and upload data when submitting it to the archive,
+as well as to download and decrypt data when retrieving it from the archive.
 
-It is recommended to use precompiled executables for `sda-cli` which can be found at https://github.com/NBISweden/sda-cli/releases
+It is recommended to use precompiled executables for `sda-cli`, which can be
+found at https://github.com/NBISweden/sda-cli/releases.
 
-To get help on the usage of the tool, please use the following command
+To get help using the tool, run the following command
 
 ```bash
 ./sda-cli help
@@ -17,333 +18,484 @@ To get help on the usage of the tool, please use the following command
 
 # Usage
 
-The main functionalities implemented in this tool are explained in the following sections.
+The main functionalities of this tool are explained in the following sections.
 
-If any command seems a bit puzzling, you can find guidance on how to interpret it right [here](https://ftpdocs.broadcom.com/cadocs/0/CA%20ARCserve%20%20Backup%2015-ENU/Bookshelf_Files/HTML/CMD_Ref/command_line_syntax_characters.htm) and [here](https://medium.com/@jaewei.j.w/how-to-read-man-page-synopsis-3408e7fd0e42).
+If any command is unclear, guidance on how to interpret it is available
+[here](https://ftpdocs.broadcom.com/cadocs/0/CA%20ARCserve%20%20Backup%2015-ENU/Bookshelf_Files/HTML/CMD_Ref/command_line_syntax_characters.htm)
+and
+[here](https://medium.com/@jaewei.j.w/how-to-read-man-page-synopsis-3408e7fd0e42).
 
 ## Encrypt
 
-The files stored in the SDA/BP archive are encrypted using the [crypt4gh standard](https://www.ga4gh.org/news/crypt4gh-a-secure-method-for-sharing-human-genetic-data/). The following sections explain how to encrypt and upload files to the archive.
+Files stored in the SDA/BP archive are encrypted using the [Crypt4GH
+standard](https://www.ga4gh.org/news/crypt4gh-a-secure-method-for-sharing-human-genetic-data/).
+The sections below explain how to encrypt and upload files to the archive.
 
-### Download the crypt4gh public key
+### Download the Crypt4GH public key file
 
-The files that are uploaded to the SDA/BP services, need to be encrypted with the correct public key. Depending on the service you want to use, this key can be downloaded using this command **if you are uploading to the SDA**:
+Files uploaded to the SDA/BP services must be encrypted with the appropriate
+public key. Depending on the service you are using, you can download
+the key file with the following commands:
+
+**For uploading to the SDA**:
 
 ```bash
 wget https://raw.githubusercontent.com/NBISweden/EGA-SE-user-docs/main/crypt4gh_key.pub
 ```
 
-or this command **if you are uploading to Big Picture**:
+**For uploading to Big Picture**:
 
 ```bash
 wget https://raw.githubusercontent.com/NBISweden/EGA-SE-user-docs/main/crypt4gh_bp_key.pub
 ```
 
-### Encrypt file(s)
+### Encrypt files
 
-Now that the public key is downloaded, the file(s) can be encrypted using the binary file created in the first step of this guide. To encrypt a specific file, use the following command:
-
-```bash
-./sda-cli encrypt [-key <public_key>] <file_to_encrypt>
-```
-
-where `<public_key>` the key downloaded in the previous step. The tool also allows for encrypting multiple files at once, by listing them separated with space like:
+After downloading the public key file, you can encrypt your files using the
+`sda-cli` executable obtained in the first step of this guide. To encrypt a
+specific file, use the following command:
 
 ```bash
-./sda-cli encrypt -key <public_key> <file_1_to_encrypt> <file_2_to_encrypt> <file_3_to_encrypt>
+./sda-cli encrypt -key <public_key_file> <file_to_encrypt>
 ```
 
-This command comes with the `-continue` option, which will continue encrypting files, even if one of them fails. To enable this feature, the command should be executed with the `-continue=true` option.
-If no public key is provided, the tool will look for it from a previous login session.
-
-### Encrypt file(s) with multiple keys
-
-To encrypt files with more than one public keys, repeatedly use the `-key` flag, e.g.
+where `<public_key_file>` is the key file downloaded in the previous step. You
+can also encrypt multiple files at once by listing them, separated by spaces,
+as shown below:
 
 ```bash
-./sda-cli encrypt -key <public_key1> -key <public_key2> <file_to_encrypt>
+./sda-cli encrypt -key <public_key_file> <file_1_to_encrypt> <file_2_to_encrypt>
 ```
 
-will encrypt a file using two keys so that it can be decrypted with either of the corresponding private keys. Encryption with more than two keys is possible, as well. Another option is to provide as argument to `-key` a file with concatenated public keys generated e.g. from a command like
+The tool also provides a `-continue` option, which allows encryption to
+continue even if one of the files fails. To enable this feature, run the
+command like this:
 
 ```bash
-cat <pub_key1> <pub_key2> > <concatenated_pub_keys>
+./sda-cli encrypt -key <public_key_file> -continue=true <file_1_to_encrypt> <file_2_to_encrypt>
 ```
 
-Passing a combination of the above arguments is allowed, as well:
+### Encrypt files with multiple keys
+
+You can encrypt files using multiple public keys by specifying the `-key` flag
+multiple times. For example:
 
 ```bash
-./sda-cli encrypt -key <concatenated_public_keys> -key <public_key3> <file_to_encrypt>
+./sda-cli encrypt -key <public_key_file1> -key <public_key_file2> <file_to_encrypt>
 ```
 
-**Note**: The `encrypt` command will create four files containing hashes (both md5 and sha256) for the encrypted and unencrypted files, respectively.
+This command encrypts the file with two keys, allowing it to be decrypted using
+either of the corresponding private keys. Encryption with more than two keys is
+also supported.
 
-**Developers' Notes:** The tool is creating a key pair when encrypting the files. This key pair is temporary for security reasons.
+Alternatively, you can use a single file containing concatenated public keys. To
+create such a file, use a command like:
+
+```bash
+cat <public_key_file1> <public_key_file2> > <concatenated_public_key_file>
+```
+
+You can then provide this concatenated key file to the `-key` argument:
+
+```bash
+./sda-cli encrypt -key <concatenated_public_key_file> <file_to_encrypt>
+```
+
+Combining both approaches is also allowed. For instance:
+
+```bash
+./sda-cli encrypt -key <concatenated_public_key_file> -key <public_key_file3> <file_to_encrypt>
+```
+
+**Note**: The `encrypt` command generates four hash files (MD5 and SHA256) for
+both the encrypted and unencrypted versions of the file.
+
+**Developer Notes**: The tool creates a temporary key pair during the encryption
+process for enhanced security.
 
 ## Upload
 
 ### Download the configuration file
 
-Once your files are encrypted, they are ready to be submitted to the SDA/BP archive. The s3 storage requires users to be authenticated, therefore a configuration file needs to be downloaded before starting the uploading of the files.
+After encrypting your files, they are ready to be uploaded to the SDA/BP
+archive. Since the S3 storage requires user authentication, you must download a
+configuration file before starting the upload process.
 
-The configuration file can be downloaded by logging in with a Life Science RI account:
+To obtain the configuration file, log in using your Life Science RI account:
 
-- For BigPicture use https://login.bp.nbis.se/
+- For BigPicture, visit https://login.bp.nbis.se/
 
-Follow the dialogue to get authenticated and then click on `Download inbox s3cmd credentials` to download the configuration file named s3cmd.conf. The configuration file should be placed in the root folder of the repository.
+Follow the dialogue to get authenticated and then click on `Download inbox s3cmd
+credentials` to download the configuration file named `s3cmd.conf`. Place this
+file in the same folder as the `sda-cli` executable you downloaded earlier.
 
-Alternatively, you can download the configuration file using the [login command](#Login).
+The access token required for authentication can be provided in one of three
+ways, listed in order of priority:
 
-The access token used to authenticate to the inbox can be supplied in 3 different ways; in the config file, as an ENV `ACCESSTOKEN` or on the command line `-accessToken <access-token>` as part of the upload command.
+1. Using the `-accessToken` flag in the command.
+2. From the `ACCESSTOKEN` environment variable.
+3. In the configuration file.
 
-The Priority order for the access token is:
+### Upload files
 
-1. Using the `-accessToken` flag
-2. From the ENV `ACCESSTOKEN`
-3. In the config file
-
-### Upload file(s)
-
-Now that the configuration file is downloaded, the file(s) can be uploaded to the archive using the binary file created in the first step of this guide. To upload a specific file, use the following command:
+Once the configuration file has been downloaded, files can be uploaded to the
+archive using the `sda-cli` executable. To upload a specific file, use the
+following command:
 
 ```bash
 ./sda-cli -config <configuration_file> upload <encrypted_file_to_upload>
 ```
 
-where `<configuration_file>` the file downloaded in the previous step and `<encrypted_file_to_upload>` a file encrypted in the earlier steps. The tool also allows for uploading multiple files at once, by listing them separated with space like:
+where `<configuration_file>` refers to the configuration file downloaded in the
+previous step, and `<encrypted_file_to_upload>` refers to a file encrypted in
+the earlier steps.
+
+The tool also supports uploading multiple files simultaneously by listing them,
+separated by spaces, as shown below:
 
 ```bash
 ./sda-cli -config <configuration_file> upload <encrypted_file_1_to_upload> <encrypted_file_2_to_upload>
 ```
 
-Note that the files will be uploaded in the base folder of the user.
+**Note**:
 
-### Upload folder(s)
+- By default, files are uploaded to the user's base directory on the archive.
+- If the input contains unencrypted files, the process will exit early. To
+override this behavior, use the `-force-unencrypted` flag.
 
-One can also upload entire directories recursively, i.e. including all contained files and folders while keeping the local folder structure. This can be achieved with the `-r` flag, e.g. running:
+### Upload folders
+
+You can upload entire directories recursively, including all contained files and
+subfolders while preserving the local folder structure. This can be done using
+the `-r` flag. For example:
 
 ```bash
 ./sda-cli -config <configuration_file> upload -r <folder_to_upload>
 ```
 
-will upload `<folder_to_upload>` as is, i.e. with the same inner folder and file structure as the local one, to the archive.
+This command uploads `<folder_to_upload>` to the archive, maintaining its internal
+folder and file structure.
 
-It is also possible to specify multiple directories and files for upload with the same command. For example,
+You can also upload multiple directories and files in a single command. For example:
 
 ```bash
 ./sda-cli -config <configuration_file> upload -r <encrypted_file_1_to_upload> <encrypted_file_2_to_upload> <folder_1_to_upload> <folder_2_to_upload>
 ```
 
-However, if `-r` is omitted in the above, any folders will be skipped during upload.
+**Note**: If the `-r` flag is omitted, any specified folders will be skipped
+during the upload.
 
 ### Upload to a different path
 
-The user can specify a different path for uploading files/folders with the `-targetDir` flag followed by the name of the folder. For example, the command:
+You can specify a custom path for uploading files or folders using the
+`-targetDir` flag, followed by the desired folder name. For example:
 
 ```bash
 ./sda-cli -config <configuration_file> upload -r <encrypted_file_1_to_upload> <folder_1_to_upload> -targetDir <upload_folder>
 ```
 
-will create `<upload_folder>` under the user's base folder with contents `<upload_folder>/<encrypted_file_1_to_upload>` and `<upload_folder>/<folder_1_to_upload>`. Note that the given `<upload_folder>` may well be a folder path, e.g. `<folder1/folder2>`, and in this case `<encrypted_file_1_to_upload>` will be uploaded to `folder1/folder2/<encrypted_file_1_to_upload>`.
+This command creates `<upload_folder>` under the user's base folder and uploads
+the contents as follows:
 
-As a side note it is possible to include all the contents of a directory with `/.`, for example,
+- `<upload_folder>/<encrypted_file_1_to_upload>`
+- `<upload_folder>/<folder_1_to_upload>`
+
+The `<upload_folder>` argument can also include a folder path, such as
+`folder1/folder2`. In this case, `<encrypted_file_1_to_upload>` will be uploaded
+to `folder1/folder2/<encrypted_file_1_to_upload>`.
+
+**Note**: To include all the contents of a directory without the directory
+itself, you can append `/.` to `<folder_to_upload>`. For instance:
 
 ```bash
 ./sda-cli -config <configuration_file> upload -r <folder_to_upload>/. -targetDir <new_folder_name>
 ```
 
-will upload all contents of `<folder_to_upload>` to `<new_folder_name>` recursively, effectively renaming `<folder_to_upload>` upon upload to the archive.
+This command uploads all the contents of `<folder_to_upload>` to
+`<new_folder_name>` recursively, effectively renaming `<folder_to_upload>` to
+`<new_folder_name>` in the archive.
 
 ### Encrypt on upload
 
-It is possible to combine the encryption and upload steps with the use of the flag `--encrypt-with-key` followed by the path of the crypt4gh public key to be used for encryption. In this case, the input list of file arguments can only contain _unencrypted_ source files. For example the following,
+You can combine the encryption and upload steps using the `-encrypt-with-key`
+flag, followed by the path to the Crypt4GH public key for encryption. In this
+case, the input list of files can only contain unencrypted files. For
+example:
 
 ```bash
-./sda-cli -config <configuration_file> upload --encrypt-with-key <public_key> <unencrypted_file_to_upload>
+./sda-cli -config <configuration_file> upload -encrypt-with-key <public_key_file> <unencrypted_file_to_upload>
 ```
 
-will encrypt `<unencrypted_file_to_upload>` using `<public_key>` as public key and upload the created `<file_to_upload.c4gh>` in the base folder of the user.
+This command encrypts `<unencrypted_file_to_upload>` using `<public_key_file>`
+and uploads the resulting `<file_to_upload.c4gh>` to the user's base folder.
 
-Encrypt on upload can be combined with any of the flags above. For example,
+The encrypt on upload feature can be combined with other flags. For example:
 
 ```bash
-./sda-cli -config <configuration_file> upload --encrypt-with-key <public_key> -r <folder_to_upload_with_unencrypted_data> -targetDir <new_folder_name>
+./sda-cli -config <configuration_file> upload -encrypt-with-key <public_key_file> -r <folder_to_upload_with_unencrypted_data> -targetDir <new_folder_name>
 ```
 
-will first encrypt all files in `<folder_to_upload_with_unencrypted_data>` and then upload the folder recursively (selecting only the created `c4gh` files) under `<new_folder_name>`.
+This command encrypts all files in `<folder_with_unencrypted_data>` and uploads
+the folder recursively (including only the resulting `.c4gh` files) under
+`<new_folder_name>`.
 
-**Notes**: The tool calls the [encrypt](#Encrypt) module internally, therefore similar behavior to that command is expected, including the creation of hash files. In addition,
+**Notes**:
 
-- For encryption with [multiple public keys](<#Encrypt-file(s)-with-multiple-keys>), concatenate all public keys into one file and pass it as the argument to `encrypt-with-key`.
-- If the input includes encrypted files, the tool will exit without performing further tasks.
-- The encrypted files will be created next to their unencrypted counterparts.
-- The tool will not overwrite existing encrypted files. It will exit early if encrypted counterparts of the source files already exist with the same source path.
-- If the flag `--force-overwrite` is used, the tool will overwrite any already existing file.
-- The cli will exit if the input has any un-encrypred files. To override that, use the flag `--force-unencrypted`.
+- The command internally calls the [encrypt](#Encrypt) module when performing
+encrypt-on-upload, mirroring its behavior, including the creation of hash files.
+- For encryption with [multiple public keys](#Encrypt-files-with-multiple-keys),
+concatenate all public keys into a single file and provide it using the
+`-encrypt-with-key` flag.
+- If the input includes already encrypted files, the process will exit without
+further processing.
+- Encrypted files are created in the same directory as their unencrypted counterparts.
+- If encrypted counterparts of the input files already exist, the process will
+exit without further processing.
+- If a file has already been uploaded, the process will exit without further
+processing. To overwrite existing files, use the `-force-overwrite` flag.
 
 ## List
 
-All the following cases require a [configuration file to be downloaded](https://github.com/NBISweden/sda-cli/blob/documentation/datset-list/README.md#download-the-configuration-file) before starting the operation, and the `list` parameter should be used.
+Before using the `list` functionality, ensure you have [downloaded the configuration file](#download-the-configuration-file).
 
 ### List uploaded files
 
-This feature returns all the files in the user's inbox recursively and can be executed using:
+You can retrieves all the files along with their sizes in the user's inbox,
+including those in subdirectories, recursively using the following command:
 
 ```bash
 ./sda-cli [-config <configuration_file>] list
 ```
 
-It also allows for requesting files/filepaths with a specified prefix using:
+You can also list files or file paths with a specific prefix by using:
 
 ```bash
 ./sda-cli [-config <configuration_file>] list <prefix>
 ```
 
-This command will return any file/path starting with the defined `<prefix>`.
-If no config is given by the user, the tool will look for a previous login from the user.
+This command will return all files or paths that start with the specified `<prefix>`.
 
-### List datasets and their files
+### List datasets
 
-To list datasets or the files within a dataset that the user has access to, the `--datasets` flag should be used and the login URL must be provided:
-
-```bash
-./sda-cli -config <configuration_file> list --datasets --url <login_url> (--bytes)
-```
-
-where `<login_url>` is the URL where the user goes for authentication. This command returns a list of accessible datasets, including the number
-of files in each dataset and the total size of it. The `--bytes` flag is optional and it will display the size of the dataset in bytes.
-
-To list the files within a particular dataset, the user must provide the dataset ID (which can be obtained by executing the previous command):
+To list datasets or the files within a dataset that the user has access to, use
+the `-datasets` flag and provide the download service URL:
 
 ```bash
-./sda-cli -config <configuration_file> list -dataset <datasetID> -url <login_url> (--bytes)
+./sda-cli -config <configuration_file> list -datasets (-bytes) -url <download-service-url>
 ```
 
-This command returns a list of files within the dataset, including their file IDs, file sizes and file paths. The `--bytes` flag is optional and it will display the size of the files in bytes.
+where `<download-service-url>` is the URL for the SDA download service. The
+command will return a list of accessible datasets, including the number of files
+and the total size of each dataset. The `-bytes` flag is optional and displays
+the dataset size in bytes when enabled.
+
+### List files within a dataset
+
+To list the files within a specific dataset, use the dataset ID (retrieved from
+the previous command):
+
+```bash
+./sda-cli -config <configuration_file> list -dataset <datasetID> (-bytes) -url <download-service-url>
+```
+
+This command returns a list of files within the sepcified dataset, including
+file IDs, sizes, and paths. The `-bytes` flag is optional and displays file
+sizes in bytes.
 
 ## Download
 
-Files and datasets can be downloaded using the `download` parameter.
-This utilizes the Download API which enables secure downloads from the SDA/BP archive.
+Before using the `download` functionality, ensure you have [downloaded the configuration file](#download-the-configuration-file).
 
-The download API allows for downloading files from the archive and it requires the user to have access to the dataset, therefore a [configuration file](#download-the-configuration-file) needs to be downloaded before starting the downloading of the files.
-For downloading files the user also needs to know the download service URL and the dataset ID. The user has several options for downloading:
+Depending on the setup of the SDA/BP services, files can be downloaded
+unencrypted or encrypted.
 
-- specific files by using their paths
-- specific files by using their file ids
-- multiple files recursively
-- multiple files by providing a text file with the paths of the files to download
-- all the files of the dataset
-- specific encrypted files
+If the service is configured for encrypted downloads, you can download files
+encrypted on the server-side by providing a
+[public key file](#create-crypt4gh-key-pair) using the `-pubkey` flag. For
+detailed instructions, refer to [download encrypted files](#download-encrypted-files).
 
-#### Download specific files of the dataset (using filepaths or file ids)
+The following options are available for downloading files:
 
-For downloading one specific file the user needs to provide the path or the id (the id should **NOT** have "/") of this file by running the command below:
+- Download specific files by their paths.
+- Download specific files by their file IDs.
+- Download multiple files recursively.
+- Download multiple files by providing a text file listing file paths.
+- Download all files in a dataset.
 
-```bash
-./sda-cli -config <configuration_file> download -dataset-id <datasetID> -url <download-service-URL> [<filepath> or <fileid>]
-```
+The file paths and fileIDs can be obtained by [listing files of a dataset](#list-files-within-a-dataset).
 
-where `<configuration_file>` the file downloaded in the [previous step](#download-the-configuration-file), `<dataset_id>` the ID of the dataset and `<filepath>` the path of the file (or `<fileid>` the id of the file) in the dataset.
-The tool also allows for downloading multiple files at once, by listing their filepaths (or file ids) separated with space and it also allows for selecting a folder where the files will be downloaded, using the `outdir` argument:
+### Download specific files of a dataset
 
-```bash
-./sda-cli -config download <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> <path/to/file1> <other/path/to/file2> ... (or <fileID_1> <fileID_2> ...)
-```
+#### Using file paths
 
-#### Download files recursively
-
-For downloading the content of a folder (including subfolders) the user need to add the `--recursive` flag followed by the path(s) of the folder(s):
+To download a specific file from a dataset by their file path, use the following
+command:
 
 ```bash
-./sda-cli -config download <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> --recursive path/to/folder1 path/to/folder2 ...
+./sda-cli -config <configuration_file> download -dataset-id <datasetID> -url <download-service-URL> <filepath>
 ```
 
-#### Download from file
+where `<configuration_file>` refers to the configuration file downloaded in the
+[previous step](#download-the-configuration-file), `<datasetID>` is the ID of
+the dataset, and `<filepath>` is the path of the file in the dataset that you
+want to download.
 
-For downloading multiple files the user can provide a text file with the paths of the files to download. The file should contain one path per line.
-In this case user needs to use the `--from-file` flag and at the end user needs to provide the path of the text file with the paths of the files to download:
+To download multiple files using their file paths, list them separated by
+spaces.
 
 ```bash
-./sda-cli -config download <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> --from-file <path/to/text_file>
+./sda-cli -config <configuration_file> download -dataset-id <datasetID> -url <download-service-url> <filepath_1> <filepath_2>
 ```
 
-#### Download all the files of the dataset
+By default, files are downloaded to the current directory. To specify a custom
+output folder, use the `-outdir` flag. Additionally, if `<filepath>` includes a
+nested folder structure, the original directory hierarchy will be preserved
+during the download process.
 
-For downloading the whole dataset the user needs add the `--dataset` flag and NOT providing any filepaths:
+#### Using file IDs
+
+Downloading specific files by their file IDs follows the same syntax as
+downloading files by file paths. The only difference is that you replace the
+file paths with their corresponding file IDs. Ensure that the file IDs do not
+contain slashes (`/`).
+
+### Download files recursively
+
+To download the contents of a folder, including all subfolders, use the
+`-recursive` flag followed by the folder path. For example:
 
 ```bash
-./sda-cli -config download <configuration_file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> --dataset
+./sda-cli -config <configuration_file> download -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> -recursive <path_to_folder> 
 ```
 
-where the dataset will be downloaded in the `<outdir>` directory be keeping the original folder structure of the dataset.
+This command preserves the folder structure of the specified directories during
+the download process.
 
-#### Download encrypted files using the download API
+To recursively download multiple folders, list them separated by spaces.
 
-When a [public key](#create-keys) is provided, you can download files that are encrypted on the server-side with that public key. The command is similar to downloading the unencrypted files except that a public key is provided through the `-pubkey` flag. For example:
+### Download files from a list file
+
+To download multiple files, you can also provide a text file containing the file
+paths. Each path should be on a separate line. Use the `-from-file` flag followed
+by the path to the text file, as shown below:
 
 ```bash
-./sda-cli -config <configuration_file> download -pubkey <public-key-file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> <filepath_1_to_download> <filepath_2_to_download> ...
+./sda-cli -config <configuration_file> download -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> -from-file <path_to_list_file>
 ```
 
-After a successful download, the encrypted files can be [decrypted](#decrypt-file) using the private key corresponding to the provided public key.
+This approach simplifies downloading large numbers of files.
 
-## Decrypt file
+### Download all the files of a dataset
 
-Given that the instructions in the [download section](#download) have been followed, the key pair and the data files should be stored in some location. The last step is to decrypt the files in order to access their content. That can be achieved using the following command:
+To download all files in a dataset, use the `-dataset` flag without providing
+any argument.
 
 ```bash
-./sda-cli decrypt -key <keypair_name>.sec.pem <file_to_decrypt>
+./sda-cli -config <configuration_file> download -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> -dataset
 ```
 
-where `<keypair_name>.sec.pem` is the private key created in the [relevant section](#create-keys) and `<file_to_decrypt>` is one of the files downloaded following the instructions of the [download section](#download-file). The `--force-overwrite` flag can be used to over-write the decrypted file if it exists and the `--clean` flag to delete the encrypted file after successful decryption.
+The dataset will be downloaded to the `<outdir>`, preserving its original folder
+structure.
 
-## Login
+### Download encrypted files
 
-You can login to download the configuration file needed for some of the the tool's operation using the login command:
+When a [public key](#create-crypt4gh-key-pair) is provided, you can download
+files encrypted on the server-side with that key. The syntax is similar to
+downloading unencrypted files, but includes the `-pubkey` flag to specify the
+public key. For example:
 
 ```bash
-./sda-cli login <login_target>
+./sda-cli -config <configuration_file> download -pubkey <public-key-file> -dataset-id <datasetID> -url <download-service-url> -outdir <outdir> <filepath_1> <filepath_2>
 ```
 
-where `login_target` is the URL to the `sda-auth` service from the [sensitive-data-archive](https://github.com/neicnordic/sensitive-data-archive/) project.
+After a successful download, the encrypted files will be saved to `<outdir>`,
+maintaining their original folder structure. These files can then be
+[decrypted](#decrypt-files) using the private key corresponding to the provided
+public key.
 
-This will open a link for the user where they can go and log in.
-After the login is complete, a configuration file will be created in the tool's directory with the name of `.sda-cli-session`
+## Create Crypt4GH key pair
 
-## Version
-
-You can get the current version of the sda-cli by running:
+To create a Crypt4GH key pair, run the following command:
 
 ```bash
-./sda-cli version
+./sda-cli createKey <name>
 ```
 
-## Htsget
+where `<name>` is the base name for the key files to be generated.
+This command will two files:
 
-You can download a (partial) file using the htsget server. You can define the name of the file you want to save the result to by using the `output` variable. If `output` is not defined, the file will keep it's original name. If the file already exists, it will not be over-written unless you use the `--force-overwrite` flag. `filename`, `host`, and `key` are required. `reference` refers to the part of the file you wish to download.
+- `<name>.pub.pem` (public key)
+- `<name>.sec.pem` (private key)
+
+**Notes**:
+
+- The keys generated with this command are intended solely for decrypting files
+that are downloaded from the archive, using the corresponding custom public key.
+- These keys **should not** be used for encrypting submission files to the archive.
+
+## Decrypt files
+
+To decrypt an encrypted file downloaded from the download service of SDA, use
+the following command:
 
 ```bash
-htsget -dataset <datasetID> -filename <filename> -reference <reference-number> -host <htsget-hostname> -pubkey <public-key-file> -output <file>
+./sda-cli decrypt -key <private-key-file> <file_to_decrypt>
 ```
 
-for example:
+where `<private-key-file>` is the private key of the [Crypt4GH key
+pair](#create-crypt4gh-key-pair) created along with the public key that has been
+used to to [download the file](#download-encrypted-files).
 
+By default, the command skips decrypting a file if its unencrypted counterpart
+already exists. To override this behavior, use the `-force-overwrite` flag.
+Optionally, the `-clean` flag can be used to delete the encrypted file after
+successful decryption. Otherwise, both the encrypted and decrypted files will
+remain after decryption.
+
+To decrypt multiple files at once, list them separated by spaces, like this:
+
+```bash
+./sda-cli decrypt -key <private-key-file> <file_1_to_decrypt> <file_2_to_decrypt>
 ```
-./sda-cli -config testing/s3cmd.conf htsget -dataset DATASET0001 -filename htsnexus_test_NA12878 -reference 11 -host http://localhost:8088 -pubkey testing/c4gh.pub.pem -output ~/tmp/result.c4gh --force-overwrite
+
+## Download files using htsget
+
+You can download a (partial) file using the htsget server. 
+
+```bash
+./sda-cli -config <configuration_file> htsget -dataset <datasetID> -filename <filepath> -reference <reference-number> -host <htsget-hostname> -pubkey <public-key-file> 
 ```
+
+where `<configuration_file>` refers to the configuration file downloaded in the
+[previous step](#download-the-configuration-file), `<datasetID>` is the ID of
+the dataset, `<filepath>` is the path of the file in the dataset that you
+want to download, `<reference-number>` specifies the specific part of the file
+to download, `<htsget-hostname>` is the URL of the htsget server, and
+`<public-key-file>` is the [public key](#create-crypt4gh-key-pair) used to
+server-side encrypt the downloaded file.
+
+By default, the downloaded file retains its original name. You can use the
+`-output` flag to specify a custom name for the file.
+Additionally, existing files will **not** be overwritten unless the `-force-overwrite`
+flag is set.
+
+---
 
 # Developers' section
 
-This section contains the information required to install, modify and run the `sda-cli` tool.
+This section contains the information required to install, modify, and run the
+`sda-cli` tool.
 
 ## Requirements
 
-The `sda-cli` is written in golang. In order to be able to modify, build and run the tool, golang (>= 1.22) needs to be installed. The instructions for installing `go` can be found [here](https://go.dev/doc/install).
+The `sda-cli` is written in Go. To modify, build, and run the tool, Go (>= 1.22)
+needs to be installed. Instructions for installing `Go` can be found
+[here](https://go.dev/doc/install).
 
 ## Build tool
 
-To build the `sda-cli` tool run the following command from the root folder of the repository
+To build the `sda-cli` tool run the following command from the root folder of
+the repository
 
 ```bash
 go build
@@ -351,16 +503,40 @@ go build
 
 This command will create an executable file in the root folder, named `sda-cli`.
 
-# Create new release
+## Create a new release
 
-The github actions include a release workflow that builds binaries for different operating systems. In order to create a new release, create a tag either using the graphical interface or through the command line. That should trigger the creation of a release with the latest code of the specified branch.
+The Github Actions include a release workflow that builds binaries for different
+operating systems. To create a new release, create a tag either using
+the graphical interface or through the command line. This should trigger the
+creation of a release with the latest code from the specified branch.
 
-In order for the automatic release to get triggered, the releases should be of the format `vX.X.X`, e.g. `v1.0.0`.
+For the automatic release to be triggered, the releases should follow the format
+`vX.X.X`, e.g., `v1.0.0`.
 
-## Update releaser
+### Update releaser
 
-Before pushing a change to the releaser, make sure to run the check for the configuration file, running:
+Before pushing a change to the releaser, make sure to check the configuration
+file by running:
 
 ```sh
 goreleaser check -f .goreleaser.yaml
 ```
+
+## Features under development
+
+### Login
+
+You can log in to download the configuration file required for some of the
+tool's operations using the login command:
+
+```bash
+./sda-cli login <login_target>
+```
+
+where `login_target` is the URL of the `sda-auth` service from the
+[sensitive-data-archive](https://github.com/neicnordic/sensitive-data-archive/)
+project.
+
+This will open a link where the user can log in.
+After login is complete, a configuration file named `.sda-cli-session` will be
+created in the tool's directory.

--- a/README.md
+++ b/README.md
@@ -543,3 +543,14 @@ project.
 This will open a link where the user can log in.
 After login is complete, a configuration file named `.sda-cli-session` will be
 created in the tool's directory.
+
+## Features for testing
+
+### Upload unencrypted files
+
+By default, `sda-cli` allows uploading only encrypted files. To override this
+restriction, use the `-force-unencrypted` flag. For example:
+
+```bash
+./sda-cli -config <configuration_file> upload -force-unencrypted <unencrypted_file_1> <unencrypted_file_2>
+```

--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ To get help using the tool, run the following command
 
 The main functionalities of this tool are explained in the following sections.
 
-If any command is unclear, guidance on how to interpret it is available
-[here](https://ftpdocs.broadcom.com/cadocs/0/CA%20ARCserve%20%20Backup%2015-ENU/Bookshelf_Files/HTML/CMD_Ref/command_line_syntax_characters.htm)
+Users unfamiliar with using a command line tools in a terminal window, may find the contents of [this article](https://ftpdocs.broadcom.com/cadocs/0/CA%20ARCserve%20%20Backup%2015-ENU/Bookshelf_Files/HTML/CMD_Ref/command_line_syntax_characters.htm)
 and
-[here](https://medium.com/@jaewei.j.w/how-to-read-man-page-synopsis-3408e7fd0e42).
+[this](https://medium.com/@jaewei.j.w/how-to-read-man-page-synopsis-3408e7fd0e42) helpful.
 
 ## Encrypt
 
@@ -260,7 +259,7 @@ Before using the `list` functionality, ensure you have [downloaded the configura
 
 ### List uploaded files
 
-You can retrieves all the files along with their sizes in the user's inbox,
+You can retrieve all the files along with their sizes in the user's inbox,
 including those in subdirectories, recursively using the following command:
 
 ```bash
@@ -309,7 +308,7 @@ Before using the `download` functionality, ensure you have [downloaded the confi
 Depending on the setup of the SDA/BP services, files can be downloaded
 unencrypted or encrypted.
 
-If the service is configured for encrypted downloads, you can download files
+If the download service is configured for encrypted downloads, you can download files
 encrypted on the server-side by providing a
 [public key file](#create-crypt4gh-key-pair) using the `-pubkey` flag. For
 detailed instructions, refer to [download encrypted files](#download-encrypted-files).
@@ -444,7 +443,7 @@ the following command:
 
 where `<private-key-file>` is the private key of the [Crypt4GH key
 pair](#create-crypt4gh-key-pair) created along with the public key that has been
-used to to [download the file](#download-encrypted-files).
+used to [download the file](#download-encrypted-files).
 
 By default, the command skips decrypting a file if its unencrypted counterpart
 already exists. To override this behavior, use the `-force-overwrite` flag.

--- a/create_key/create_key.go
+++ b/create_key/create_key.go
@@ -13,28 +13,30 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Help text and command line flags.
-
-// Usage text that will be displayed as command line help text when using the
-// `help encrypt` command
+// Usage text that will be displayed when the `help createKey` command is invoked.
 var Usage = `
-USAGE: %s createKey (-outdir <dirname>) <name>
+Usage: %s createKey [OPTIONS] NAME 
 
-createKey:
-    Creates a crypt4gh encryption key pair, and saves it to
-    <name>.pub.pem, and <name>.sec.pem.
+Generate a Crypt4GH encryption key pair and saves the keys as:
+  - <name>.pub.pem (public key)
+  - <name>.sec.pem (private key)
 
-    NOTE:
-        Keys created using this function should not be used when
-        encrypting submission files, they should only be used for
-        decrypting files downloaded from the archive.
+Important:
+  Keys generated with this command are intended for decrypting files 
+  downloaded from the archive. They should NOT be used for encrypting 
+  submission files.
+
+Options:
+  -outdir <dirname>  Directory where the generated keys will be saved. 
+                     If not specified, the current directory is used.
+
+Arguments:
+    NAME             The basename of the keyfiles to generate.
 `
 
 // ArgHelp is the suffix text that will be displayed after the argument list in
 // the module help.
-var ArgHelp = `
-    [name]
-        The basename of the keyfiles to generate.`
+var ArgHelp = "" 
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/create_key/create_key.go
+++ b/create_key/create_key.go
@@ -15,7 +15,7 @@ import (
 
 // Usage text that will be displayed when the `help createKey` command is invoked.
 var Usage = `
-Usage: %s createKey [OPTIONS] NAME 
+Usage: %s createKey [OPTIONS] <name>
 
 Generate a Crypt4GH encryption key pair and saves the keys as:
   - <name>.pub.pem (public key)
@@ -31,12 +31,7 @@ Options:
                      If not specified, the current directory is used.
 
 Arguments:
-    NAME             The basename of the keyfiles to generate.
-`
-
-// ArgHelp is the suffix text that will be displayed after the argument list in
-// the module help.
-var ArgHelp = "" 
+    <name>           The basename of the keyfiles to generate.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -14,19 +14,24 @@ import (
 	"github.com/neicnordic/crypt4gh/streaming"
 )
 
-// Help text and command line flags.
-
-// Usage text that will be displayed as command line help text when using the
-// `help decrypt` command
+// Usage text that will be displayed when the `help decrypt` command is invoked.
 var Usage = `
-USAGE: %s decrypt -key <private-key-file> (--force-overwrite) (--clean) [file(s)]
+Usage: %s decrypt -key <private-key-file> [OPTIONS] [file(s)]
 
-decrypt:
-    Decrypts files from the Sensitive Data Archive (SDA) with the
-    provided private key.  If the private key is encrypted, the password
-    can be supplied in the C4GH_PASSWORD environment variable, or at the
-    interactive password prompt. The --force-overwrite flag will overwrite
-	existing files, and the --clean flag will remove the encrypted file.
+Decrypt files from the Sensitive Data Archive (SDA) using the specified private key.
+If the private key is password-protected, the password can be provided via the
+C4GH_PASSWORD environment variable or an interactive password prompt.
+
+Required options:
+  -key <private-key-file>  The private key to use for decryption.
+
+Optional options:
+  -force-overwrite         Overwrite existing files without confirmation.
+  -clean                   Remove the encrypted files after successful decryption.
+
+Arguments:
+  [file(s)]                One or more files to decrypt. All flagless arguments are
+                           treated as filenames for decryption.
 `
 
 // ArgHelp is the suffix text that will be displayed after the argument list in

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -31,14 +31,7 @@ Optional options:
 
 Arguments:
   [file(s)]                One or more files to decrypt. All flagless arguments are
-                           treated as filenames for decryption.
-`
-
-// ArgHelp is the suffix text that will be displayed after the argument list in
-// the module help
-var ArgHelp = `
-    [file(s)]
-        All flagless arguments will be used as filenames for decryption.`
+                           treated as filenames for decryption.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/download/download.go
+++ b/download/download.go
@@ -56,12 +56,7 @@ Optional options:
 
 Arguments:
   [filepath(s)]          Specific file paths to download.
-  [fileid(s)]            File IDs of files to download.
-`
-
-// ArgHelp is the suffix text that will be displayed after the argument list in
-// the module help
-var ArgHelp = ""
+  [fileid(s)]            File IDs of files to download.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/download/download.go
+++ b/download/download.go
@@ -133,7 +133,7 @@ func Download(args []string, configPath string) error {
 	// Check if -from-file flag is set and only one file is provided
 	if *fromFile && len(Args.Args()) != 1 {
 		return fmt.Errorf(
-			"one file should be provided with -from-file flag",
+			"one file should be provided with the -from-file flag",
 		)
 	}
 

--- a/download/download.go
+++ b/download/download.go
@@ -26,7 +26,7 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help download` command
 var Usage = `
-Usage: %s [-config CONFIGFILE] download [OPTIONS] [ARGUMENTS]
+Usage: %s [-config <config-file>] download [OPTIONS] [ARGUMENTS]
 
 Download files from the Sensitive Data Archive (SDA) using APIs at the
 specified URL. The user must have the necessary access rights (visas) to the
@@ -40,7 +40,7 @@ Important:
     - -from-file <list-filepath>
 
 Global options:
-  -config CONFIGFILE     Path to the configuration file. 
+  -config <config-file>       Path to the configuration file. 
   
 Required options: 
   -dataset-id <datasetID>     Dataset ID for the file(s) to download.

--- a/download/download.go
+++ b/download/download.go
@@ -35,24 +35,24 @@ datasets being downloaded.
 Important:
   Provide exactly one of the following options to specify files to download:
     - [filepath(s) or fileid(s)] 
-    - --dataset 
-    - --recursive <dirpath> 
-    - --from-file <list-filepath>
+    - -dataset
+    - -recursive <dirpath>
+    - -from-file <list-filepath>
 
 Global options:
   -config CONFIGFILE     Path to the configuration file. 
   
 Required options: 
-  -dataset-id <datasetID>      Dataset ID for the file(s) to download. 
-  -url <uri>                   The url of the download server. 
+  -dataset-id <datasetID>     Dataset ID for the file(s) to download.
+  -url <uri>                  The url of the download server.
 
 Optional options:
-  --pubkey <public-key-file>   Encrypt downloaded files server-side using the specified public key.
-  -outdir <dir>                Directory to save the downloaded files.
-                               If not specified, files will be saved in the current directory.
-  --dataset                    Download all files in the dataset specified by '-dataset-id'.
-  --recursive <dirpath>        Download all files recursively from the given directory path.
-  --from-file <list-filepath>  Download all files listed in the specified file.
+  -pubkey <public-key-file>   Encrypt downloaded files server-side using the specified public key.
+  -outdir <dir>               Directory to save the downloaded files.
+                              If not specified, files will be saved in the current directory.
+  -dataset                    Download all files in the dataset specified by '-dataset-id'.
+  -recursive <dirpath>        Download all files recursively from the given directory path.
+  -from-file <list-filepath>  Download all files listed in the specified file.
 
 Arguments:
   [filepath(s)]          Specific file paths to download.
@@ -109,12 +109,12 @@ func Download(args []string, configPath string) error {
 		return fmt.Errorf("missing required arguments, dataset, config and url are required")
 	}
 
-	// Check if both --recursive and --dataset flags are set
+	// Check if both -recursive and -dataset flags are set
 	if *recursiveDownload && *datasetdownload {
-		return fmt.Errorf("both --recursive and --dataset flags are set, choose one of them")
+		return fmt.Errorf("both -recursive and -dataset flags are set, choose one of them")
 	}
 
-	// Check that file(s) are not missing if the --dataset flag is not set
+	// Check that file(s) are not missing if the -dataset flag is not set
 	if len(Args.Args()) == 0 && !*datasetdownload {
 		if !*recursiveDownload {
 			return fmt.Errorf("no files provided for download")
@@ -123,17 +123,17 @@ func Download(args []string, configPath string) error {
 		return fmt.Errorf("no folders provided for recursive download")
 	}
 
-	// Check if --dataset flag is set and files are provided
+	// Check if -dataset flag is set and files are provided
 	if *datasetdownload && len(Args.Args()) > 0 {
 		return fmt.Errorf(
-			"files provided with --dataset flag, add either the flag or the file(s), not both",
+			"files provided with -dataset flag, add either the flag or the file(s), not both",
 		)
 	}
 
-	// Check if --from-file flag is set and only one file is provided
+	// Check if -from-file flag is set and only one file is provided
 	if *fromFile && len(Args.Args()) != 1 {
 		return fmt.Errorf(
-			"one file should be provided with --from-file flag",
+			"one file should be provided with -from-file flag",
 		)
 	}
 
@@ -150,11 +150,11 @@ func Download(args []string, configPath string) error {
 	}
 
 	switch {
-	// Case where the user is setting the --dataset flag
+	// Case where the user is setting the -dataset flag
 	// then download all the files in the dataset.
-	// Case where the user is setting the --recursive flag
+	// Case where the user is setting the -recursive flag
 	// then download the content of the path
-	// Case where the user is setting the --from-file flag
+	// Case where the user is setting the -from-file flag
 	// then download the files from the file list
 	// Default case, download the provided files.
 	case *datasetdownload:

--- a/download/download.go
+++ b/download/download.go
@@ -26,33 +26,42 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help download` command
 var Usage = `
-USAGE: %s -config <s3config-file> download -dataset-id <datasetID> -url <uri> (--pubkey <public-key-file>) (-outdir <dir>) ([filepath(s) or fileid(s)] or --dataset or --recursive <dirpath>) or --from-file <list-filepath>
+Usage: %s [-config CONFIGFILE] download [OPTIONS] [ARGUMENTS]
 
-download:
-	Downloads files from the Sensitive Data Archive (SDA) by using APIs from the given url. The user
-	must have been granted access to the datasets (visas) that are to be downloaded.
-	The files will be downloaded in the current directory, if outdir is not defined.
-	When the -pubkey flag is used, the downloaded files will be server-side encrypted with the given public key.
-    If the --dataset flag is used, all files in the dataset will be downloaded.
-    If the --recursive flag is used, all files in the directory will be downloaded.
-    If the --from-file flag is used, all the files that are in the file will be downloaded.
-    `
+Download files from the Sensitive Data Archive (SDA) using APIs at the
+specified URL. The user must have the necessary access rights (visas) to the
+datasets being downloaded.
+
+Important:
+  Provide exactly one of the following options to specify files to download:
+    - [filepath(s) or fileid(s)] 
+    - --dataset 
+    - --recursive <dirpath> 
+    - --from-file <list-filepath>
+
+Global options:
+  -config CONFIGFILE     Path to the configuration file. 
+  
+Required options: 
+  -dataset-id <datasetID>      Dataset ID for the file(s) to download. 
+  -url <uri>                   The url of the download server. 
+
+Optional options:
+  --pubkey <public-key-file>   Encrypt downloaded files server-side using the specified public key.
+  -outdir <dir>                Directory to save the downloaded files.
+                               If not specified, files will be saved in the current directory.
+  --dataset                    Download all files in the dataset specified by '-dataset-id'.
+  --recursive <dirpath>        Download all files recursively from the given directory path.
+  --from-file <list-filepath>  Download all files listed in the specified file.
+
+Arguments:
+  [filepath(s)]          Specific file paths to download.
+  [fileid(s)]            File IDs of files to download.
+`
 
 // ArgHelp is the suffix text that will be displayed after the argument list in
 // the module help
-var ArgHelp = `
-	[datasetID]
-		The ID of the dataset that the file is part of.
-	[uri]
-		All flagless arguments will be used as download uri.
-	[filepath(s)]
-		The filepath of the file to download.
-    	[fileid(s)]
-        	The file ID of the file to download.
-    	[dirpath]
-        	The directory path to download all files recursively.
-        [list-filepath]
-            The path to the file that contains the list of files to download.`
+var ArgHelp = ""
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -28,24 +28,35 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help encrypt` command
 var Usage = `
-USAGE: %s encrypt -key <public-key-file> (-target <target>) (-outdir <dir>) (-continue=true) [file(s)]
+Usage: %s encrypt [OPTIONS] [file(s)] 
 
-encrypt:
-    Encrypts files according to the crypt4gh standard used in the
-    Sensitive Data Archive (SDA).  Each given file will be encrypted
-    and written to <filename>.c4gh.  Both encrypted and unencrypted
-    checksums will be calculated and written to:
-        - checksum_unencrypted.md5
-        - checksum_encrypted.md5
-        - checksum_unencrypted.sha256
-        - checksum_encrypted.sha256
+Encrypt files according to the Crypt4GH standard used in the Sensitive Data
+Archive (SDA). Each input file will be encrypted and saved as '<filename>.c4gh'.
+Additionally, checksums for both encrypted and unencrypted files will be
+calculated and written to the following files:
+  - checksum_unencrypted.md5
+  - checksum_encrypted.md5
+  - checksum_unencrypted.sha256
+  - checksum_encrypted.sha256
+
+Important:
+  Exactly one of '-key' or '-target' must be specified.
+
+Options:
+  -key <public-key-file>   Public key file(s) to use for encryption. This flag can be specified 
+                           multiple times to encrypt files with multiple public keys.
+                           Key files may contain concatenated keys.
+  -target <target>         Client target associated with the public key.
+  -outdir <dir>            Output directory for encrypted files. Defaults to the current directory.
+  -continue=true|false     Skip files with errors and continue processing others. Defaults to 'false'.
+
+Arguments:
+  [file(s)]                List of file paths to be encrypted. All flagless arguments are treated as filenames.
 `
 
 // ArgHelp is the suffix text that will be displayed after the argument list in
 // the module help
-var ArgHelp = `
-    [files]
-        All flagless arguments will be used as filenames for encryption.`
+var ArgHelp = ""
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help
@@ -54,14 +65,14 @@ var Args = flag.NewFlagSet("encrypt", flag.ExitOnError)
 var outDir = Args.String("outdir", "",
 	"Output directory for encrypted files.")
 
-var continueEncrypt = Args.Bool("continue", false, "Do not exit on file errors but skip and continue.")
+var continueEncrypt = Args.Bool("continue", false, "Skip files with errors and continue processing others. Defaults to 'false'.")
 
-var target = Args.String("target", "", "Client target for public key.")
+var target = Args.String("target", "", "Client target associated with the public key.")
 
 var publicKeyFileList []string
 
 func init() {
-	Args.Func("key", "Public key file(s) to use for encryption. Use multiple times to encrypt\nwith more public keys. Key file(s) may contain many concatenated keys.", func(s string) error {
+	Args.Func("key", "Public key file(s) to use for encryption. This flag can be specified\nmultiple times to encrypt files with multiple public keys. \nKey files may contain concatenated keys.", func(s string) error {
 		publicKeyFileList = append(publicKeyFileList, s)
 
 		return nil

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -51,12 +51,8 @@ Options:
   -continue=true|false     Skip files with errors and continue processing others. Defaults to 'false'.
 
 Arguments:
-  [file(s)]                List of file paths to be encrypted. All flagless arguments are treated as filenames.
-`
-
-// ArgHelp is the suffix text that will be displayed after the argument list in
-// the module help
-var ArgHelp = ""
+  [file(s)]                List of file paths to be encrypted.
+                           All flagless arguments are treated as filenames.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/htsget/htsget.go
+++ b/htsget/htsget.go
@@ -20,12 +20,12 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help htsget` command
 var Usage = `
-Usage: %s [-config CONFIGFILE] htsget [OPTIONS]
+Usage: %s [-config <config-file>] htsget [OPTIONS]
 
 Download files from the Sensitive Data Archive (SDA) using the htsget server.
 
 Global options:
-  -config CONFIGFILE     Path to the configuration file. 
+  -config <config-file>       Path to the configuration file. 
 
 Required options:
   -dataset <datasetID>        Dataset ID for the file to download.

--- a/htsget/htsget.go
+++ b/htsget/htsget.go
@@ -20,28 +20,30 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help htsget` command
 var Usage = `
-USAGE: %s -config testing/s3cmd.conf htsget [-dataset <datasetID>] [-filename <filename>] (-reference <referenceName>) [-htsgethost <htsget-hostname>] [-pubkey <public-key-file>] (-output <file>) (--force-overwrite)
+Usage: %s [-config CONFIGFILE] htsget [OPTIONS]
 
-htsget:
-	Htsget downloads files from the Sensitive Data Archive (SDA), using the
-	htsget server. A dataset and a filename must be provided in order to 
-	download the file. The files will be downloaded in the current
-	directory, if output is not defined.
+Download files from the Sensitive Data Archive (SDA) using the htsget server.
+
+Global options:
+  -config CONFIGFILE     Path to the configuration file. 
+
+Required options:
+  -dataset <datasetID>        Dataset ID for the file to download.
+  -filename <filename>        Name of the file to download.
+  -host <hostname>            Hostname of the htsget server to use.
+  -pubkey <public-key-file>   Encrypt downloaded files server-side using the specified public key.
+
+Optional options:
+  -reference <referenceName>  Specify a reference name to download a partial file. 
+  -output <file>              Output name for the downloaded file. 
+                              If not specified, the file will be downloaded to the current directory
+                              as the original filename.
+  --force-overwrite           Overwrite existing files without prompting.
 `
 
 // ArgHelp is the suffix text that will be displayed after the argument list in
 // the module help
-var ArgHelp = `
-    [dataset]
-        The ID of the dataset that the file is part of.
-    [filename]
-        The name of the file to download.
-    [reference]
-        The reference number of the file to download.
-    [host]
-        The hostname of the htsget server to use.
-    [pubkey]
-        The public key file to use for the htsget request.`
+var ArgHelp = ""
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/htsget/htsget.go
+++ b/htsget/htsget.go
@@ -38,7 +38,7 @@ Optional options:
   -output <file>              Output name for the downloaded file. 
                               If not specified, the file will be downloaded to the current directory
                               as the original filename.
-  --force-overwrite           Overwrite existing files without prompting.`
+  -force-overwrite            Overwrite existing files without prompting.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help
@@ -169,7 +169,7 @@ func downloadFiles(htsgeURLs htsgetResponse, config *helpers.Config) (err error)
 	}
 
 	if helpers.FileExists(filenameToUse) && !*forceOverwrite {
-		return fmt.Errorf("local file already exists, use --force-overwrite to overwrite")
+		return fmt.Errorf("local file already exists, use -force-overwrite to overwrite")
 	}
 	out, err := os.OpenFile(filenameToUse, os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {

--- a/htsget/htsget.go
+++ b/htsget/htsget.go
@@ -38,12 +38,7 @@ Optional options:
   -output <file>              Output name for the downloaded file. 
                               If not specified, the file will be downloaded to the current directory
                               as the original filename.
-  --force-overwrite           Overwrite existing files without prompting.
-`
-
-// ArgHelp is the suffix text that will be displayed after the argument list in
-// the module help
-var ArgHelp = ""
+  --force-overwrite           Overwrite existing files without prompting.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/list/list.go
+++ b/list/list.go
@@ -18,23 +18,32 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help list` command
 var Usage = `
-USAGE: %s [-config <s3config-file>] list [prefix] (-url <uri> --datasets) (-url <uri> --dataset <dataset-id>) [-bytes]
+Usage: %s [-config CONFIGFILE] list [prefix] [OPTIONS]
 
-list:
-    Lists recursively all files under the user's folder in the Sensitive
-    Data Archive (SDA).  If the [prefix] parameter is used, only the
-    files under the specified path will be returned. If no config is
-	specified, the tool will look for a previous session. The --datasets
-	flag will list all datasets in the user's folder, given the url of
-	the	htsgetserver. The --dataset flag will list all files in the
-	specified dataset and the dataset size.
+Recursively list files and datasets in the user's folder in the Sensitive Data
+Archive (SDA). By default, it lists all files under the user's folder. Use the
+optional [prefix] argument to list files under a specific path. 
+
+Important:
+  If using '-datasets' or '-dataset', the '-url' flag is required to specify
+  the SDA download server URL.
+
+Global options:
+  -config CONFIGFILE      Path to the configuration file.
+
+Options:
+  -bytes                  Display file sizes in bytes instead of a human-readable format.
+  -dataset <dataset-id>   List all files in the specified dataset, including the dataset size.
+  -datasets               List all datasets available in the user's folder.
+  -url <uri>              Specify the SDA download server URL when using '-datasets' or '-dataset'.
+
+Arguments:
+  [prefix]                Optional prefix to filter results to a specific location or folder path.
 `
 
 // ArgHelp is the suffix text that will be displayed after the argument list in
 // the module help
-var ArgHelp = `
-    [prefix]
-        The location/folder of the s3 to list contents.`
+var ArgHelp = ""
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/list/list.go
+++ b/list/list.go
@@ -18,7 +18,7 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help list` command
 var Usage = `
-Usage: %s [-config CONFIGFILE] list [prefix] [OPTIONS]
+Usage: %s [-config <config-file>] list [prefix] [OPTIONS]
 
 Recursively list files and datasets in the user's folder in the Sensitive Data
 Archive (SDA). By default, it lists all files under the user's folder. Use the
@@ -29,7 +29,7 @@ Important:
   the SDA download server URL.
 
 Global options:
-  -config CONFIGFILE      Path to the configuration file.
+  -config <config-file>   Path to the configuration file.
 
 Options:
   -bytes                  Display file sizes in bytes instead of a human-readable format.

--- a/list/list.go
+++ b/list/list.go
@@ -38,12 +38,7 @@ Options:
   -url <uri>              Specify the SDA download server URL when using '-datasets' or '-dataset'.
 
 Arguments:
-  [prefix]                Optional prefix to filter results to a specific location or folder path.
-`
-
-// ArgHelp is the suffix text that will be displayed after the argument list in
-// the module help
-var ArgHelp = ""
+  [prefix]                Optional prefix to filter results to a specific location or folder path.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/login/login.go
+++ b/login/login.go
@@ -25,18 +25,18 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help login` command
 var Usage = `
+Usage: %s login <login-target>
 
-USAGE: %s login <login-target>
+Authenticates the user with the Sensitive Data Archive (SDA) using the specified login target.
 
-login:
-    logs in to the SDA using the provided login target.
+Arguments:
+  <login-target>   The base URL of the service to log in to. This is required 
+                   and determines the SDA service to authenticate against.
 `
 
 // ArgHelp is the suffix text that will be displayed after the argument list in
 // the module help
-var ArgHelp = `
-    [login-target]
-        The login target is the base URL of the service.`
+var ArgHelp = ""
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/login/login.go
+++ b/login/login.go
@@ -31,12 +31,7 @@ Authenticates the user with the Sensitive Data Archive (SDA) using the specified
 
 Arguments:
   <login-target>   The base URL of the service to log in to. This is required 
-                   and determines the SDA service to authenticate against.
-`
-
-// ArgHelp is the suffix text that will be displayed after the argument list in
-// the module help
-var ArgHelp = ""
+                   and determines the SDA service to authenticate against.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	createKey "github.com/NBISweden/sda-cli/create_key"
 	"github.com/NBISweden/sda-cli/decrypt"
@@ -186,6 +187,13 @@ func Help(command string) error {
 
 		// print main help
 		fmt.Println(Usage)
+
+		// Print link to the README
+		readmeURL := "https://github.com/NBISweden/sda-cli/blob/main/README.md"
+		if !strings.Contains(Version, "development") {
+			readmeURL = fmt.Sprintf("https://github.com/NBISweden/sda-cli/blob/%s/README.md", Version)
+		}
+		fmt.Println("For more information, see the README at:", readmeURL)
 
 		if command == "help" {
 			return nil

--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/NBISweden/sda-cli/decrypt"
 	"github.com/NBISweden/sda-cli/download"
 	"github.com/NBISweden/sda-cli/encrypt"
-	"github.com/NBISweden/sda-cli/helpers"
 	"github.com/NBISweden/sda-cli/htsget"
 	"github.com/NBISweden/sda-cli/list"
 	"github.com/NBISweden/sda-cli/login"
@@ -19,12 +18,34 @@ import (
 )
 
 var Version = "0-development"
+const ExecName = "sda-cli"
 
-var Usage = `USAGE: %s -config <s3config-file> <command> [command-args]
+var Usage = fmt.Sprintf(`
+Usage: %s [-config CONFIGFILE] <command> [OPTIONS]
 
-This is a helper tool that can help with common tasks when interacting
-with the Sensitive Data Archive (SDA).
-`
+A tool for common tasks with the Sensitive Data Archive (SDA)
+
+Commands:
+  createKey   Creates a Crypt4GH key pair
+  decrypt     Decrypt files
+  download    Download files from SDA
+  encrypt     Encrypt files
+  htsget      Get files using htsget
+  list        List files in the SDA
+  login       Login to the SDA
+  upload      Upload files to the SDA
+
+Global options:
+  -config CONFIGFILE  Path to the configuration file
+  -h, -help           Show this help message
+  -v, -version        Show the version of the tool
+
+Additional commands:
+  version          Show the version of the tool
+  help             Show this help message
+
+Run '%s help <command>' for more information on a command.
+`, ExecName, ExecName)
 
 // Map of the sub-commands, and their arguments and usage text strings
 type commandInfo struct {
@@ -80,9 +101,11 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+
+	os.Exit(0)
 }
 
-// Parses the command line arguments into a command, and keep the rest
+// Parse the command line arguments into a command, and keep the rest
 // of the arguments for the subcommand.
 func ParseArgs() (string, []string, string) {
 	var configPath string
@@ -152,7 +175,7 @@ func ParseArgs() (string, []string, string) {
 	return command, os.Args, configPath
 }
 
-// Prints the main usage string, and the global help or command help
+// Print the main usage string, and the global help or command help
 // depending on the command argument.  Returns an error if the command
 // is not recognized.
 func Help(command string) error {
@@ -163,15 +186,7 @@ func Help(command string) error {
 		}
 
 		// print main help
-		fmt.Fprintf(os.Stderr, Usage, os.Args[0])
-		fmt.Fprintln(os.Stderr, "The tool can help with these actions:")
-		for _, info := range Commands {
-			subcommandUsage := helpers.FormatSubcommandUsage(info.usage)
-			fmt.Fprint(os.Stderr, subcommandUsage)
-		}
-		fmt.Fprintf(os.Stderr,
-			"use '%s help <command>' to get help with subcommand flags.\n",
-			os.Args[0])
+		fmt.Println(Usage)
 
 		if command == "help" {
 			return nil
@@ -180,11 +195,11 @@ func Help(command string) error {
 		return fmt.Errorf("unknown command: %s", command)
 	}
 
-	// print subcommand help
-	fmt.Fprintf(os.Stderr, info.usage+"\n", os.Args[0])
-	fmt.Fprintln(os.Stderr, "Command line arguments:")
-	info.args.PrintDefaults()
-	fmt.Fprintln(os.Stderr, info.argHelp)
+	// Print subcommand help
+	fmt.Printf(info.usage+"\n", ExecName)
+	// fmt.Println("Command line arguments:")
+	// info.args.PrintDefaults()
+	// fmt.Println(info.argHelp)
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ var Version = "0-development"
 const ExecName = "sda-cli"
 
 var Usage = fmt.Sprintf(`
-Usage: %s [-config CONFIGFILE] <command> [OPTIONS]
+Usage: %s [-config <config-file>] <command> [OPTIONS]
 
 A tool for common tasks with the Sensitive Data Archive (SDA)
 
@@ -37,9 +37,9 @@ Commands:
   upload      Upload files to the SDA
 
 Global options:
-  -config CONFIGFILE  Path to the configuration file
-  -h, -help           Show this help message
-  -v, -version        Show the version of the tool
+  -config <config-file>  Path to the configuration file
+  -h, -help              Show this help message
+  -v, -version           Show the version of the tool
 
 Additional commands:
   version          Show the version of the tool

--- a/main.go
+++ b/main.go
@@ -33,7 +33,6 @@ Commands:
   encrypt     Encrypt files
   htsget      Get files using htsget
   list        List files in the SDA
-  login       Login to the SDA
   upload      Upload files to the SDA
 
 Global options:

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 )
 
 var Version = "0-development"
+
 const ExecName = "sda-cli"
 
 var Usage = fmt.Sprintf(`
@@ -49,21 +50,20 @@ Run '%s help <command>' for more information on a command.
 
 // Map of the sub-commands, and their arguments and usage text strings
 type commandInfo struct {
-	args    *flag.FlagSet
-	usage   string
-	argHelp string
+	args  *flag.FlagSet
+	usage string
 }
 
 var Commands = map[string]commandInfo{
-	"encrypt":   {encrypt.Args, encrypt.Usage, encrypt.ArgHelp},
-	"createKey": {createKey.Args, createKey.Usage, createKey.ArgHelp},
-	"decrypt":   {decrypt.Args, decrypt.Usage, decrypt.ArgHelp},
-	"upload":    {upload.Args, upload.Usage, upload.ArgHelp},
-	"list":      {list.Args, list.Usage, list.ArgHelp},
-	"htsget":    {htsget.Args, htsget.Usage, htsget.ArgHelp},
-	"login":     {login.Args, login.Usage, login.ArgHelp},
-	"download":  {download.Args, download.Usage, download.ArgHelp},
-	"version":   {version.Args, version.Usage, version.ArgHelp},
+	"encrypt":   {encrypt.Args, encrypt.Usage},
+	"createKey": {createKey.Args, createKey.Usage},
+	"decrypt":   {decrypt.Args, decrypt.Usage},
+	"upload":    {upload.Args, upload.Usage},
+	"list":      {list.Args, list.Usage},
+	"htsget":    {htsget.Args, htsget.Usage},
+	"login":     {login.Args, login.Usage},
+	"download":  {download.Args, download.Usage},
+	"version":   {version.Args, version.Usage},
 }
 
 // Main does argument parsing, then delegates to one of the sub modules
@@ -197,9 +197,6 @@ func Help(command string) error {
 
 	// Print subcommand help
 	fmt.Printf(info.usage+"\n", ExecName)
-	// fmt.Println("Command line arguments:")
-	// info.args.PrintDefaults()
-	// fmt.Println(info.argHelp)
 
 	return nil
 }

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -25,20 +25,38 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help upload` command
 var Usage = `
-USAGE: %s -config <s3config-file> upload (-accessToken <access-token>) (--encrypt-with-key <public-key-file>) (--force-overwrite) (--force-unencrypted) (-r) [file(s) | folder(s)] (-targetDir <upload-directory>)
+Usage: %s -config CONFIGFILE upload [OPTIONS] [file(s)|folder(s)]
 
-upload:
-    Uploads files to the Sensitive Data Archive (SDA).
-    All files to upload are required to be crypt4gh encrypted when the flag -encrypt-with-key is not set.
-    On the other hand, non-encrypted files should be provided when the flag -encrypt-with-key is set.
+Upload files or directories to the Sensitive Data Archive (SDA). 
+
+Important:
+  - Files must be encrypted (Crypt4GH standard) unless the '-encrypt-with-key' flag is set.
+  - When using the '-encrypt-with-key' flag, ensure that only unencrypted files are provided.
+  - Use the '-force-unencrypted' flag with caution to upload unencrypted files explicitly.
+
+Options:
+  -accessToken <access-token>      Access token for the SDA inbox service. This is optional 
+                                   if already set in the config file or as the 'ACCESSTOKEN' 
+                                   environment variable.
+  -encrypt-with-key <public-key-file>
+                                   Encrypt files using the specified public key before upload. 
+                                   The key file may contain multiple concatenated public keys. 
+                                   Only unencrypted files should be provided when this flag is used.
+  -force-overwrite                 Overwrite existing files in the target directory without confirmation.
+  -force-unencrypted               Allow uploading unencrypted files (use with caution).
+  -r                               Upload directories recursively. Without this flag, directories 
+                                   will be skipped.
+  -targetDir <upload-directory>    Specify the target directory for uploaded files or folders. 
+                                   Defaults to the user's base directory if not set.
+
+Arguments:
+  [file(s) | folder(s)]            List of files or directories to upload. Directories are 
+                                   skipped unless the '-r' flag is provided.
 `
 
 // ArgHelp is the suffix text that will be displayed after the argument list in
 // the module help
-var ArgHelp = `
-    [file(s)|folder(s)]
-        All flagless arguments will be used as file or directory names
-        to upload.  Directories will be skipped if '-r' is not provided.`
+var ArgHelp = ""
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -51,12 +51,7 @@ Options:
 
 Arguments:
   [file(s) | folder(s)]            List of files or directories to upload. Directories are 
-                                   skipped unless the '-r' flag is provided.
-`
-
-// ArgHelp is the suffix text that will be displayed after the argument list in
-// the module help
-var ArgHelp = ""
+                                   skipped unless the '-r' flag is provided.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -25,7 +25,7 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help upload` command
 var Usage = `
-Usage: %s -config CONFIGFILE upload [OPTIONS] [file(s)|folder(s)]
+Usage: %s -config <config-file> upload [OPTIONS] [file(s) | folder(s)]
 
 Upload files or directories to the Sensitive Data Archive (SDA). 
 
@@ -33,6 +33,9 @@ Important:
   - Files must be encrypted (Crypt4GH standard) unless the '-encrypt-with-key' flag is set.
   - When using the '-encrypt-with-key' flag, ensure that only unencrypted files are provided.
   - Use the '-force-unencrypted' flag with caution to upload unencrypted files explicitly.
+
+Global options:
+  -config <config-file>       	   Path to the configuration file. 
 
 Options:
   -accessToken <access-token>      Access token for the SDA inbox service. This is optional 

--- a/version/version.go
+++ b/version/version.go
@@ -18,16 +18,9 @@ import (
 // Usage text that will be displayed as command line help text when using the
 // `help version` command
 var Usage = `
-USAGE: %s version
+Usage: %s version
 
-version:
-    Returns the version of the sda-cli tool.
-`
-
-// ArgHelp is the suffix text that will be displayed after the argument list in
-// the module help
-var ArgHelp = `
-    version does not take any arguments`
+Show the version of the sda-cli tool.`
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #478 

**Changes made**
- The help message follows similar style as Docker 
- The main help message becomes concise and shows the list of commands with a brief description without verbose instructions.
- Help message of the sub commands are collected in a single string variable to keep a uniformed style, e.g., uniformed indentation. 
- All flags are shown with single dash to remove the ambiguity.
- Errors and outdated descriptions in the README are corrected.
- Descriptions related to `login` are removed in the README and the `login` section is moved to a new section `Features under development`
- A README link specific to the version is printed in the main help message.

**How to test**
