### PR TITLE
More human friendly token expiry date messages

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -398,26 +398,26 @@ func CheckTokenExpiration(accessToken string) error {
 	}
 
 	switch untilExp := time.Until(expiration); {
-	case untilExp < 0:
+	case untilExp <= 0:
 		return fmt.Errorf("the provided access token has expired, please renew it")
-	case untilExp >= 0 && untilExp < 2*time.Hour:
+	case untilExp > 0 && untilExp < 2*time.Hour:
 		fmt.Fprintf(
 			os.Stderr,
-			"WARNING! The provided access token expires in only %d hours and %d minutes.\n",
+			"WARNING! The provided access token expires in only %d hour and %d minutes.\n",
 			int(untilExp.Hours()), int(untilExp.Minutes())-(int(untilExp.Hours())*60),
 		)
 		fmt.Fprintln(os.Stderr, "Consider renewing the token.")
 	case untilExp >= 2*time.Hour && untilExp < 24*time.Hour:
 		fmt.Fprintf(
 			os.Stderr,
-			"The provided access token expires in %d hours and %d minutes (at %d:%d).\n",
-			int(untilExp.Hours()), int(untilExp.Minutes())-(int(untilExp.Hours())*60), expiration.Hour(), expiration.Minute(),
+			"The provided access token expires in %d hours and %d minutes.\n",
+			int(untilExp.Hours()), int(untilExp.Minutes())-(int(untilExp.Hours())*60),
 		)
 		fmt.Fprintln(os.Stderr, "Consider renewing the token.")
 	default:
 		fmt.Fprintf(
 			os.Stderr,
-			"The provided access token expires on %s.\n", expiration.Format("2006-01-02"),
+			"The provided access token expires on %s.\n", expiration.Format(time.RFC1123),
 		)
 	}
 

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -398,27 +398,27 @@ func CheckTokenExpiration(accessToken string) error {
 	}
 
 	switch untilExp := time.Until(expiration); {
-	case untilExp <= 0:
-		return fmt.Errorf("the provided access token has expired, please renew it")
-	case untilExp > 0 && untilExp < 2*time.Hour:
+	case untilExp >= 1*time.Minute && untilExp < 2*time.Hour:
 		fmt.Fprintf(
 			os.Stderr,
 			"WARNING! The provided access token expires in only %d hour and %d minutes.\n",
 			int(untilExp.Hours()), int(untilExp.Minutes())-(int(untilExp.Hours())*60),
 		)
 		fmt.Fprintln(os.Stderr, "Consider renewing the token.")
-	case untilExp >= 2*time.Hour && untilExp < 24*time.Hour:
+	case untilExp >= 2*time.Hour && untilExp <= 24*time.Hour:
 		fmt.Fprintf(
 			os.Stderr,
 			"The provided access token expires in %d hours and %d minutes.\n",
 			int(untilExp.Hours()), int(untilExp.Minutes())-(int(untilExp.Hours())*60),
 		)
 		fmt.Fprintln(os.Stderr, "Consider renewing the token.")
-	default:
+	case untilExp > 24*time.Hour:
 		fmt.Fprintf(
 			os.Stderr,
 			"The provided access token expires on %s.\n", expiration.Format(time.RFC1123),
 		)
+	default:
+		return fmt.Errorf("the provided access token has expired, please renew it")
 	}
 
 	return nil

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -398,15 +398,18 @@ func CheckTokenExpiration(accessToken string) error {
 	}
 
 	switch untilExp := time.Until(expiration); {
-	case untilExp >= 1*time.Minute && untilExp < 2*time.Hour:
-		hourString := ""
-		if int(untilExp.Hours()) != 0 {
-			hourString = "1 hour and "
-		}
+	case untilExp >= 1*time.Minute && untilExp < time.Hour:
 		fmt.Fprintf(
 			os.Stderr,
-			"WARNING! The provided access token expires in only %s%d minutes.\n",
-			hourString, int(untilExp.Minutes())-(int(untilExp.Hours())*60),
+			"WARNING! The provided access token expires in only %d minutes.\n",
+			int(untilExp.Minutes())-(int(untilExp.Hours())*60),
+		)
+		fmt.Fprintln(os.Stderr, "Consider renewing the token.")
+	case untilExp >= 1*time.Hour && untilExp < 2*time.Hour:
+		fmt.Fprintf(
+			os.Stderr,
+			"WARNING! The provided access token expires in only 1 hour and %d minutes.\n",
+			int(untilExp.Minutes())-(int(untilExp.Hours())*60),
 		)
 		fmt.Fprintln(os.Stderr, "Consider renewing the token.")
 	case untilExp >= 2*time.Hour && untilExp <= 24*time.Hour:

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -399,10 +399,14 @@ func CheckTokenExpiration(accessToken string) error {
 
 	switch untilExp := time.Until(expiration); {
 	case untilExp >= 1*time.Minute && untilExp < 2*time.Hour:
+		hourString := ""
+		if int(untilExp.Hours()) != 0 {
+			hourString = "1 hour and "
+		}
 		fmt.Fprintf(
 			os.Stderr,
-			"WARNING! The provided access token expires in only %d hour and %d minutes.\n",
-			int(untilExp.Hours()), int(untilExp.Minutes())-(int(untilExp.Hours())*60),
+			"WARNING! The provided access token expires in only %s%d minutes.\n",
+			hourString, int(untilExp.Minutes())-(int(untilExp.Hours())*60),
 		)
 		fmt.Fprintln(os.Stderr, "Consider renewing the token.")
 	case untilExp >= 2*time.Hour && untilExp <= 24*time.Hour:

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -400,18 +400,24 @@ func CheckTokenExpiration(accessToken string) error {
 	switch untilExp := time.Until(expiration); {
 	case untilExp < 0:
 		return fmt.Errorf("the provided access token has expired, please renew it")
-	case untilExp > 0 && untilExp < 24*time.Hour:
-		fmt.Fprintln(
+	case untilExp >= 0 && untilExp < 2*time.Hour:
+		fmt.Fprintf(
 			os.Stderr,
-			"The provided access token expires in",
-			time.Until(expiration).Truncate(time.Second),
+			"WARNING! The provided access token expires in only %d hours and %d minutes.\n",
+			int(untilExp.Hours()), int(untilExp.Minutes())-(int(untilExp.Hours())*60),
+		)
+		fmt.Fprintln(os.Stderr, "Consider renewing the token.")
+	case untilExp >= 2*time.Hour && untilExp < 24*time.Hour:
+		fmt.Fprintf(
+			os.Stderr,
+			"The provided access token expires in %d hours and %d minutes (at %d:%d).\n",
+			int(untilExp.Hours()), int(untilExp.Minutes())-(int(untilExp.Hours())*60), expiration.Hour(), expiration.Minute(),
 		)
 		fmt.Fprintln(os.Stderr, "Consider renewing the token.")
 	default:
-		fmt.Fprintln(
+		fmt.Fprintf(
 			os.Stderr,
-			"The provided access token expires in",
-			time.Until(expiration).Truncate(time.Second),
+			"The provided access token expires on %s.\n", expiration.Format("2006-01-02"),
 		)
 	}
 

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -341,7 +341,7 @@ func (suite *HelperTests) TestTokenExpiration() {
 	out, _ := io.ReadAll(r)
 	os.Stderr = storeStderr
 
-	msg := "WARNING! The provided access token expires in only 0 hours and 59 minutes."
+	msg := "WARNING! The provided access token expires in only 0 hour and 59 minutes."
 	assert.Contains(suite.T(), string(out), msg)
 
 	// Token with valid expiration, more than a day
@@ -359,7 +359,7 @@ func (suite *HelperTests) TestTokenExpiration() {
 	out, _ = io.ReadAll(r)
 	os.Stderr = storeStderr
 
-	msg = "The provided access token expires on " + exp.Format("2006-01-02")
+	msg = "The provided access token expires on " + exp.Format(time.RFC1123)
 	assert.Contains(suite.T(), string(out), msg)
 }
 

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -341,7 +341,7 @@ func (suite *HelperTests) TestTokenExpiration() {
 	out, _ := io.ReadAll(r)
 	os.Stderr = storeStderr
 
-	msg := "WARNING! The provided access token expires in only 0 hour and 59 minutes."
+	msg := "WARNING! The provided access token expires in only 59 minutes."
 	assert.Contains(suite.T(), string(out), msg)
 
 	// Token with valid expiration, more than a day


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #437. Now token expiry messages to the user follow the output pattern that is listed in the issue description. 

**How to test**
Tests have been added to the go testsuite, so
```
go test ./...
```
should be enough.

Note: The `download integration` tests fail because of the latest change where `sda-download` serves only `/s3` whereas `sda-cli` looks for `s3-encrypted`. This is irrelevant to this PR though (see temporary fix #501)