### PR TITLE
use last version that supports /s3-encrypted

### DIFF
--- a/testing/docker-compose.yml
+++ b/testing/docker-compose.yml
@@ -201,7 +201,7 @@ services:
       - GRPC_PORT=50051
       - GRPC_HOST=reencrypt
       - APP_SERVEUNENCRYPTEDDATA=true
-    image: "ghcr.io/neicnordic/sensitive-data-archive:${TAG}-download"
+    image: "ghcr.io/neicnordic/sensitive-data-archive:v0.3.179-download" #this is the last version that supports /s3-encrypted
     volumes:
       - ./archive_data/4293c9a7-dc50-46db-b79a-27ddc0dad1c6:/tmp/4293c9a7-dc50-46db-b79a-27ddc0dad1c6
     mem_limit: 256m


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR temporarily fixes the failing integration tests that were caused by removing the `s3-encrypted` endpoint from download's API in a [recent PR](https://github.com/neicnordic/sensitive-data-archive/pull/1163).


I added a note to undo this fix when #497 is done.