### PR TITLE
Remove usage of s3-encrypted

### DIFF
--- a/.github/integration/tests/40_download.sh
+++ b/.github/integration/tests/40_download.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 set -e
 
-# Download file by using the sda-cli download command
-./sda-cli -config testing/s3cmd-download.conf download -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir test-download main/subfolder/dummy_data.c4gh
+# Create a user key pair
+if ( yes "" | ./sda-cli createKey user_key ) ; then
+    echo "Created a user key pair for downloading encrypted files"
+else
+    echo "Failed to create a user key pair for downloading encrypted files"
+    exit 1
+fi
 
+# Download file by using the sda-cli download command
+./sda-cli -config testing/s3cmd-download.conf download -pubkey user_key.pub.pem -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir test-download main/subfolder/dummy_data.c4gh
+
+C4GH_PASSWORD="" ./sda-cli decrypt -key user_key.sec.pem test-download/main/subfolder/dummy_data.c4gh
 # Check if file exists in the path
 if [ ! -f "test-download/main/subfolder/dummy_data" ]; then
     echo "Downloaded file not found"
@@ -20,13 +29,13 @@ fi
 rm -r test-download
 
 # Download whole dataset by using the sda-cli download command
-./sda-cli -config testing/s3cmd-download.conf download -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-dataset --dataset
+./sda-cli -config testing/s3cmd-download.conf download -pubkey user_key.pub.pem  -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-dataset --dataset
 
 filepaths="download-dataset/main/subfolder/dummy_data download-dataset/main/subfolder2/dummy_data2 download-dataset/main/subfolder2/random/dummy_data3"
 
 # Check if all the files of the dataset have been downloaded
 for filepath in $filepaths; do
-    if [ ! -f "$filepath" ]; then
+    if [ ! -f "$filepath.c4gh" ]; then
         echo "File $filepath does not exist"
         exit 1
     fi
@@ -34,13 +43,6 @@ done
 
 rm -r download-dataset
 
-# Create a user key pair
-if ( yes "" | ./sda-cli createKey user_key ) ; then
-    echo "Created a user key pair for downloading encrypted files"
-else
-    echo "Failed to create a user key pair for downloading encrypted files"
-    exit 1
-fi
 # Download encrypted file by using the sda-cli download command
 ./sda-cli -config testing/s3cmd-download.conf download -pubkey user_key.pub.pem -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir test-download main/subfolder/dummy_data.c4gh
 
@@ -69,13 +71,13 @@ fi
 
 # Download recursively a folder
 echo "Downloading content of folder"
-./sda-cli -config testing/s3cmd-download.conf download -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-folder --recursive main/subfolder2
+./sda-cli -config testing/s3cmd-download.conf download -pubkey user_key.pub.pem -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-folder --recursive main/subfolder2
 
 folderpaths="download-folder/main/subfolder2/dummy_data2 download-folder/main/subfolder2/random/dummy_data3"
 
 # Check if the content of the folder has been downloaded
 for folderpath in $folderpaths; do
-    if [ ! -f "$folderpath" ]; then
+    if [ ! -f "$folderpath.c4gh" ]; then
         echo "Content of folder $folderpath is missing"
         exit 1
     fi
@@ -84,14 +86,15 @@ done
 rm -r download-folder
 
 # Download dataset by providing the dataset id
-./sda-cli -config testing/s3cmd-download.conf download -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-fileid urn:neic:001-001
+./sda-cli -config testing/s3cmd-download.conf download -pubkey user_key.pub.pem -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-fileid urn:neic:001-001
 
 # Check if file exists in the path
-if [ ! -f "download-fileid/main/subfolder/dummy_data" ]; then
+if [ ! -f "download-fileid/main/subfolder/dummy_data.c4gh" ]; then
     echo "Downloaded file by using the file id not found"
     exit 1
 fi
 
+C4GH_PASSWORD="" ./sda-cli decrypt -key user_key.sec.pem download-fileid/main/subfolder/dummy_data.c4gh
 # Check the first line of the file
 first_line_id=$(head -n 1 download-fileid/main/subfolder/dummy_data)
 if [[ $first_line_id != *"THIS FILE IS JUST DUMMY DATA"* ]]; then
@@ -103,10 +106,10 @@ rm -r download-fileid
 
 # Download the file paths content of a text file
 echo "Downloading content of a text file"
-./sda-cli -config testing/s3cmd-download.conf download -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-from-file --from-file testing/file-list.txt
+./sda-cli -config testing/s3cmd-download.conf download -pubkey user_key.pub.pem -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-from-file --from-file testing/file-list.txt
 
 # Check if the content of the text file has been downloaded
-content_paths="download-from-file/main/subfolder/dummy_data download-from-file/main/subfolder2/dummy_data2"
+content_paths="download-from-file/main/subfolder/dummy_data.c4gh download-from-file/main/subfolder2/dummy_data2.c4gh"
 
 for content_path in $content_paths; do
     if [ ! -f "$content_path" ]; then
@@ -115,6 +118,7 @@ for content_path in $content_paths; do
     fi
 done
 
+C4GH_PASSWORD="" ./sda-cli decrypt -key user_key.sec.pem download-from-file/main/subfolder/dummy_data.c4gh
 # Check the first line of the file
 first_line_file=$(head -n 1 download-from-file/main/subfolder/dummy_data)
 if [[ $first_line_file != *"THIS FILE IS JUST DUMMY DATA"* ]]; then
@@ -122,7 +126,14 @@ if [[ $first_line_file != *"THIS FILE IS JUST DUMMY DATA"* ]]; then
     exit 1
 fi
 
+# Make sure files cannot be downloaded without giving a public key
+if ./sda-cli -config testing/s3cmd-download.conf download -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir test-download main/subfolder/dummy_data.c4gh; then
+  echo "Downloaded a file without using a public key"
+  exit 1
+fi
+
 rm -r download-from-file
 rm -r test-download
+
 
 echo "Integration tests for sda-cli download finished successfully"

--- a/.github/integration/tests/40_download.sh
+++ b/.github/integration/tests/40_download.sh
@@ -128,8 +128,10 @@ fi
 
 # Make sure files cannot be downloaded without giving a public key
 if ./sda-cli -config testing/s3cmd-download.conf download -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir test-download main/subfolder/dummy_data.c4gh; then
-  echo "Downloaded a file without using a public key"
-  exit 1
+    echo "Downloaded a file without using a public key"
+    exit 1
+else
+    echo "Error expected, continue."
 fi
 
 rm -r download-from-file

--- a/download/download.go
+++ b/download/download.go
@@ -401,7 +401,7 @@ func getFileIDURL(baseURL, token, pubKeyBase64, dataset, filename string) (strin
 	if pubKeyBase64 == "" {
 		url = baseURL + "/files/" + datasetFiles[idx].FileID
 	} else {
-		url = baseURL + "/s3-encrypted/" + dataset + "/" + filename
+		url = baseURL + "/s3/" + dataset + "/" + filename
 	}
 
 	return url, datasetFiles[idx].FilePath, nil

--- a/download/download.go
+++ b/download/download.go
@@ -396,13 +396,7 @@ func getFileIDURL(baseURL, token, pubKeyBase64, dataset, filename string) (strin
 		return "", "", fmt.Errorf("File not found in dataset %s", filename)
 	}
 
-	var url string
-	// If no public key is provided, retrieve the unencrypted file
-	if pubKeyBase64 == "" {
-		url = baseURL + "/files/" + datasetFiles[idx].FileID
-	} else {
-		url = baseURL + "/s3/" + dataset + "/" + filename
-	}
+	url := baseURL + "/s3/" + dataset + "/" + filename
 
 	return url, datasetFiles[idx].FilePath, nil
 }

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -170,10 +170,12 @@ func (suite *TestSuite) TestDownloadUrl() {
 
 	//-----------------------------------------------
 	// Test using a nonempty public key
-	// Test with valid base_url, token, dataset, and filename
+	// Test with valid base_url, token, dataset, and fileid
+	filepath = "path/to/file1.c4gh"
+	fileid := "file1id"
 	expectedURL = baseURL + "/s3/" + datasetID + "/" + filepath
 	pubKey := "test-public-key"
-	url, _, err = getFileIDURL(baseURL, token, pubKey, datasetID, filepath)
+	url, _, err = getFileIDURL(baseURL, token, pubKey, datasetID, fileid)
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), expectedURL, url)
 

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -171,7 +171,7 @@ func (suite *TestSuite) TestDownloadUrl() {
 	//-----------------------------------------------
 	// Test using a nonempty public key
 	// Test with valid base_url, token, dataset, and filename
-	expectedURL = baseURL + "/s3-encrypted/" + datasetID + "/" + filepath
+	expectedURL = baseURL + "/s3/" + datasetID + "/" + filepath
 	pubKey := "test-public-key"
 	url, _, err = getFileIDURL(baseURL, token, pubKey, datasetID, filepath)
 	assert.NoError(suite.T(), err)
@@ -179,7 +179,7 @@ func (suite *TestSuite) TestDownloadUrl() {
 
 	// Test with url as dataset
 	datasetID = "https://doi.example/another/url/001"
-	expectedURL = baseURL + "/s3-encrypted/" + datasetID + "/" + filepath
+	expectedURL = baseURL + "/s3/" + datasetID + "/" + filepath
 	url, _, err = getFileIDURL(baseURL, token, pubKey, datasetID, filepath)
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), expectedURL, url)

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -138,7 +138,7 @@ func (suite *TestSuite) TestDownloadUrl() {
 	token := suite.accessToken
 	datasetID := "test-dataset"
 	filepath := "path/to/file1"
-	expectedURL := "https://some/url/files/file1id"
+	expectedURL := "https://some/url/s3/test-dataset/path/to/file1.c4gh"
 
 	//-----------------------------------------------
 	// Test with an empty public key

--- a/htsget/htsget_test.go
+++ b/htsget/htsget_test.go
@@ -134,7 +134,7 @@ KKj6NUcJGZ2/HeqkYbxm57ZaFLP5cIHsdK+0nQubFVs=
         "url": "data:;base64,Y3J5cHQ0Z2gBAAAAAgAAAA=="
       },
       {
-        "url": "http://localhost/s3-encrypted/DATASET0001/htsnexus_test_NA12878.bam.c4gh",
+        "url": "http://localhost/s3/DATASET0001/htsnexus_test_NA12878.bam.c4gh",
         "headers": {
           "Range": "bytes=16-123",
           "accept-encoding": "gzip",
@@ -148,7 +148,7 @@ KKj6NUcJGZ2/HeqkYbxm57ZaFLP5cIHsdK+0nQubFVs=
         "url": "data:;base64,ZAAAAAAAAAB7zX5e64IzHWf5/X8nkdCKpwsX0eT4/AHU77sh2+EdIXwkSEyPQ5ZP2+vRHvytn6H1hf63Wo7gPdDc59KZfz+10kjywPqQUXYOoSbeQ6cxx2dxmf2nSwSd2Wh1jA=="
       },
       {
-        "url": "http://localhost/s3-encrypted/DATASET0001/htsnexus_test_NA12878.bam.c4gh",
+        "url": "http://localhost/s3/DATASET0001/htsnexus_test_NA12878.bam.c4gh",
         "headers": {
           "Range": "bytes=124-1049147",
           "accept-encoding": "gzip",
@@ -159,7 +159,7 @@ KKj6NUcJGZ2/HeqkYbxm57ZaFLP5cIHsdK+0nQubFVs=
         }
       },
       {
-        "url": "http://localhost/s3-encrypted/DATASET0001/htsnexus_test_NA12878.bam.c4gh",
+        "url": "http://localhost/s3/DATASET0001/htsnexus_test_NA12878.bam.c4gh",
         "headers": {
           "Range": "bytes=2557120-2598042",
           "accept-encoding": "gzip",

--- a/testing/docker-compose.yml
+++ b/testing/docker-compose.yml
@@ -201,7 +201,7 @@ services:
       - GRPC_PORT=50051
       - GRPC_HOST=reencrypt
       - APP_SERVEUNENCRYPTEDDATA=true
-    image: "ghcr.io/neicnordic/sensitive-data-archive:v0.3.179-download" #this is the last version that supports /s3-encrypted
+    image: "ghcr.io/neicnordic/sensitive-data-archive:${TAG}-download"
     volumes:
       - ./archive_data/4293c9a7-dc50-46db-b79a-27ddc0dad1c6:/tmp/4293c9a7-dc50-46db-b79a-27ddc0dad1c6
     mem_limit: 256m


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #497 .


**Description**
-  Usage and references to `/s3-encrypted` are replaced with `/s3`.
- The latest tag will be used for the image of download.
- The endpoint `/files` will not be used anymore, as it is for encrypted data
- Support for removing the user name part of the filepath is improved (but can be removed when we merge [`feature/do-not-leak-user-ids`](https://github.com/neicnordic/sensitive-data-archive/tree/feature/do-not-leak-user-ids) )
- Encrypted files are expected
- Tests are updated 

**How to test**
Use `sda-cli` to dowload files.

**To do**
- [ ] Make a release to v0.1.4