### PR TITLE
display host_base

### DIFF
--- a/.github/integration/tests/30_list.sh
+++ b/.github/integration/tests/30_list.sh
@@ -13,7 +13,7 @@ fi
 # Check listing files in a dataset
 output=$(./sda-cli -config testing/s3cmd-download.conf list -dataset https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080)
 expected="FileIDSizePathurn:neic:001-0011.0MB5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8_elixir-europe.org/main/subfolder/dummy_data.c4ghurn:neic:001-0021.0MB5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8_elixir-europe.org/main/subfolder2/dummy_data2.c4ghurn:neic:001-0031.0MB5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8_elixir-europe.org/main/subfolder2/random/dummy_data3.c4ghDatasetsize:3.1MB"
-if [[ "${output//[$' \t\n\r']/}" == "${expected//[$' \t\n\r']/}" ]];  then
+if [[ "${output//[$' \t\n\r']/}" == *"${expected//[$' \t\n\r']/}"* ]];  then
     echo "Successfully listed files in dataset"
 else
     echo "Failed to list files in dataset"

--- a/.github/integration/tests/40_download.sh
+++ b/.github/integration/tests/40_download.sh
@@ -2,7 +2,13 @@
 set -e
 
 # Download file by using the sda-cli download command
-./sda-cli -config testing/s3cmd-download.conf download -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir test-download main/subfolder/dummy_data.c4gh
+output=$(./sda-cli -config testing/s3cmd-download.conf download -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir test-download main/subfolder/dummy_data.c4gh)
+
+# Check if we print the host_base in the output
+if [[ $output != *"host_base: localhost:8000"* ]]; then
+    echo "host_base not found in the output"
+    exit 1
+fi
 
 # Check if file exists in the path
 if [ ! -f "test-download/main/subfolder/dummy_data" ]; then

--- a/.github/integration/tests/40_download.sh
+++ b/.github/integration/tests/40_download.sh
@@ -10,13 +10,7 @@ else
 fi
 
 # Download file by using the sda-cli download command
-output=$(./sda-cli -config testing/s3cmd-download.conf download -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir test-download main/subfolder/dummy_data.c4gh)
-
-# Check if we print the host_base in the output
-if [[ $output != *"host_base: localhost:8000"* ]]; then
-    echo "host_base not found in the output"
-    exit 1
-fi
+./sda-cli -config testing/s3cmd-download.conf download -pubkey user_key.pub.pem -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir test-download main/subfolder/dummy_data.c4gh
 
 C4GH_PASSWORD="" ./sda-cli decrypt -key user_key.sec.pem test-download/main/subfolder/dummy_data.c4gh
 # Check if file exists in the path

--- a/download/download.go
+++ b/download/download.go
@@ -149,6 +149,9 @@ func Download(args []string, configPath string) error {
 		return err
 	}
 
+	// print the host_base for the user
+	fmt.Printf("host_base: %s\n", config.HostBase)
+
 	switch {
 	// Case where the user is setting the -dataset flag
 	// then download all the files in the dataset.

--- a/download/download.go
+++ b/download/download.go
@@ -155,7 +155,7 @@ func Download(args []string, configPath string) error {
 	}
 
 	// print the host_base for the user
-	fmt.Printf("host_base: %s\n", config.HostBase)
+	fmt.Printf("Remote server (host_base): %s\n", config.HostBase)
 
 	switch {
 	// Case where the user is setting the -dataset flag

--- a/download/download.go
+++ b/download/download.go
@@ -107,7 +107,7 @@ func Download(args []string, configPath string) error {
 	}
 
 	if *datasetID == "" || *URL == "" || configPath == "" {
-		return fmt.Errorf("missing required arguments, dataset, config and url are required")
+		return fmt.Errorf("missing required arguments, dataset-id, config and url are required")
 	}
 
 	// Check if both -recursive and -dataset flags are set

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -1,11 +1,13 @@
 package download
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -82,6 +84,28 @@ func (suite *TestSuite) TestInvalidUrl() {
 	)
 }
 
+func (suite *TestSuite) TestPrintHostBase() {
+	confPath := createConfigFile("s3cmd.conf", suite.accessToken)
+
+	os.Args = []string{
+		"download",
+		"-dataset-id",
+		"TES01",
+		"-url",
+		"https://some/url",
+		"file1",
+	}
+
+	var str bytes.Buffer
+	log.SetOutput(&str)
+	defer log.SetOutput(os.Stdout)
+
+	// check if the host_base is in the output
+	expectedHostBase := "host_base: inbox.dummy.org"
+	_ = Download(os.Args, confPath.Name())
+	logMsg := fmt.Sprintf("%v", strings.TrimSuffix(str.String(), "\n"))
+	assert.Contains(suite.T(), expectedHostBase, logMsg)
+}
 func (suite *TestSuite) TestGetBody() {
 	// Create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/list/list.go
+++ b/list/list.go
@@ -75,6 +75,10 @@ func List(args []string, configPath string) error {
 	if err != nil {
 		return err
 	}
+
+	// print the host_base for the user
+	fmt.Printf("host_base: %s\n", config.HostBase)
+
 	// case datasets
 	if *datasets {
 		err := Datasets(config.AccessToken)

--- a/list/list.go
+++ b/list/list.go
@@ -77,7 +77,7 @@ func List(args []string, configPath string) error {
 	}
 
 	// print the host_base for the user
-	fmt.Printf("host_base: %s\n", config.HostBase)
+	fmt.Printf("Remote server (host_base): %s\n", config.HostBase)
 
 	// case datasets
 	if *datasets {

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -150,4 +150,8 @@ func (suite *TestSuite) TestFunctionality() {
 	listOutput, _ := io.ReadAll(r)
 	msg1 := fmt.Sprintf("%v", filepath.Base(testfile.Name()))
 	assert.Contains(suite.T(), string(listOutput), msg1)
+
+	// Check if host_base is in the output
+	expectedHostBase := strings.TrimPrefix(ts.URL, "http://")
+	assert.Contains(suite.T(), string(listOutput), expectedHostBase)
 }

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -152,6 +152,6 @@ func (suite *TestSuite) TestFunctionality() {
 	assert.Contains(suite.T(), string(listOutput), msg1)
 
 	// Check if host_base is in the output
-	expectedHostBase := strings.TrimPrefix(ts.URL, "http://")
+	expectedHostBase := "Remote server (host_base): " + strings.TrimPrefix(ts.URL, "http://")
 	assert.Contains(suite.T(), string(listOutput), expectedHostBase)
 }

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -319,7 +319,7 @@ func Upload(args []string, configPath string) error {
 	}
 
 	// print the host_base for the user
-	fmt.Printf("host_base: %s\n", config.HostBase)
+	fmt.Printf("Remote server (host_base): %s\n", config.HostBase)
 
 	// Check that input file/folder list is not empty
 	if len(Args.Args()) == 0 {

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -318,6 +318,9 @@ func Upload(args []string, configPath string) error {
 		return err
 	}
 
+	// print the host_base for the user
+	fmt.Printf("host_base: %s\n", config.HostBase)
+
 	// Check that input file/folder list is not empty
 	if len(Args.Args()) == 0 {
 		return errors.New("no files to upload")

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -249,6 +249,10 @@ func (suite *TestSuite) TestFunctionality() {
 	msg = fmt.Sprintf("file uploaded to %s/dummy/%s/%s", ts.URL, filepath.ToSlash(targetPath), filepath.Base(testfile.Name()))
 	assert.Contains(suite.T(), logMsg, msg)
 
+	// check if the host_base is in the output
+	expectedHostBase := strings.TrimPrefix(ts.URL, "http://")
+	assert.Contains(suite.T(), logMsg, expectedHostBase)
+
 	// Check that file showed up in the s3 bucket correctly
 	result, err = s3Client.ListObjects(&s3.ListObjectsInput{
 		Bucket: aws.String("dummy"),

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -217,7 +217,6 @@ func (suite *TestSuite) TestFunctionality() {
 
 	var str bytes.Buffer
 	log.SetOutput(&str)
-	//defer log.SetOutput(os.Stdout)
 
 	// Test recursive upload
 	os.Args = []string{"upload", "--force-unencrypted", "-r", dir}


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #294 .


**Description**
Display `host_base` when running a command that requires a config file (download, list, upload).

**How to test**
Manually, run any command from **download**, **list**, **upload**. They should all display the `host_base`.
Or run the test suite. **list** and **upload** use unit tests while **download** an integration test. 