### PR TITLE
Show only status code from s3's seralization error message

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -460,7 +460,7 @@ func ListFiles(config Config, prefix string) (result *s3.ListObjectsV2Output, er
 			re := regexp.MustCompile(`(status code: \d*)`)
 			errorCode := re.FindString(err.Error())
 			if errorCode != "" {
-				err = fmt.Errorf("Problem connecting to s3: %s", errorCode)
+				err = fmt.Errorf("problem connecting to s3: %s", errorCode)
 			}
 		}
 

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -454,7 +454,16 @@ func ListFiles(config Config, prefix string) (result *s3.ListObjectsV2Output, er
 		Bucket: aws.String(config.AccessKey + "/"),
 		Prefix: aws.String(config.AccessKey + "/" + prefix),
 	})
+
 	if err != nil {
+		if strings.HasPrefix(err.Error(), "SerializationError") {
+			re := regexp.MustCompile(`(status code: \d*)`)
+			errorCode := re.FindString(err.Error())
+			if errorCode != "" {
+				err = fmt.Errorf("Problem connecting to s3: %s", errorCode)
+			}
+		}
+
 		return nil, fmt.Errorf("failed to list objects, reason: %v", err)
 	}
 


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #381 .

**Description**
When s3 is down, the function `svc.ListObjectsV2` , used [here](https://github.com/NBISweden/sda-cli/blob/main/helpers/helpers.go#L453) will return an error message which is already broken. That is, it is a seralization error, the one shown in #381.
This PR gets the status code from that error blob, and prints that to the user.

Current output:
```
The provided access token expires on Mon, 03 Mar 2025 12:33:13 CET.
Error: listing uploaded files: failed to list objects, reason: Problem connecting to s3: status code: 503
```



**How to test**
Pro tip from Jocke: As long as  `staging-inbox.fega.nbis.se` is down, you can use that for testing this. Simply set `host_base = staging-inbox.fega.nbis.se` in your `s3cmd.conf` and run
```
sda-cli -config s3cmd.conf upload  -encrypt-with-key c4gh.pub.pem t1.txt
```
Make sure the output looks as described above.

When it is not working:

Unfortunately, this is not trivial to test. We do not get the same error when running the standard docker development setup (`make sda-s3-up`). Here's one way to reproduce:
- ~Either hack s3inbox so that it does not care about authenticating the user's token, or find a way to get the correct token from the k3d setup of sensitive data archive~
- Use the k3d deployment of sensitive data archive [described here](https://github.com/neicnordic/sensitive-data-archive?tab=readme-ov-file#testing-and-developing-the-helm-charts-locally).
- Make sure minio (s3) is unavailable: `kubectl scale deployment  minio  --replicas=0 --namespace=minio`
- Update your `s3cmd.cfg` config, setting `host_base = inbox.127.0.0.1.nip.io`
- Run `sda-cli -config s3cmd.conf upload  -encrypt-with-key c4gh.pub.pem /tmp/t1.txt`


**Additional notes**
The error when testing the same thing with the docker setup is this:
```
sda-cli -config s3cmd.conf upload  -encrypt-with-key c4gh.pub.pem /tmp/t1.txt
The provided access token expires on Mon, 03 Mar 2025 12:33:13 CET.
Error: listing uploaded files: failed to list objects, reason: Internal Server Error: Internal server error for request (&{GET /inbox/?list-type=2&prefix=testu_lifescience-ri.eu%2Ft8.txt.c4gh HTTP/1.1 1 1 map[Accept-Encoding:[gzip] Authorization:[AWS4-HMAC-SHA256 Credential=access/20250226/us-east-1/s3/aws4_request, SignedHeaders=accept-encoding;host;x-amz-content-sha256;x-amz-date, Signature=98eb494ccb513af23ca882ebf9881af22f4aafcad97de9ab356230cef2dd3449] User-Agent:[aws-sdk-go/1.55.6 (go1.24.0; linux; amd64)] X-Amz-Content-Sha256:[e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855] X-Amz-Date:[20250226T124115Z]] {} <nil> 0 [] false s3:9000 map[] map[] <nil> map[] 172.21.0.1:54470 /testu_lifescience-ri.eu/?list-type=2&prefix=testu_lifescience-ri.eu%2Ft8.txt.c4gh <nil> <nil> <nil>  0xc000191230 <nil> [] map[]})
```

Although very verbose, it is still informative, so I kept it as is. Feel free to have opinions about this.