### PR TITLE
 [list] use pagination to list s3 objects

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -244,7 +244,7 @@ type Config struct {
 	SocketTimeout        int    `ini:"socket_timeout"`
 	HumanReadableSizes   bool   `ini:"human_readable_sizes"`
 	PublicKey            string `ini:"public_key"`
-	MaxS3Keys            int64  // changes MaxKeys of the aws SDK, only used by tests
+	MaxS3Keys            int64  // changes MaxKeys of the aws SDK, only used by tests. Default is 1000.
 }
 
 // LoadConfigFile loads ini configuration file to the Config struct

--- a/list/list.go
+++ b/list/list.go
@@ -94,7 +94,7 @@ func List(args []string, configPath string) error {
 		return nil
 	}
 
-	result, err := helpers.ListFiles(*config, prefix)
+	result, err := helpers.ListFiles(*config, prefix, -1)
 	if err != nil {
 		return err
 	}

--- a/list/list.go
+++ b/list/list.go
@@ -94,7 +94,7 @@ func List(args []string, configPath string) error {
 		return nil
 	}
 
-	result, err := helpers.ListFiles(*config, prefix, -1)
+	result, err := helpers.ListFiles(*config, prefix)
 	if err != nil {
 		return err
 	}

--- a/list/list.go
+++ b/list/list.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"strconv"
-
 	"strings"
 
 	"github.com/NBISweden/sda-cli/download"
@@ -100,9 +99,9 @@ func List(args []string, configPath string) error {
 		return err
 	}
 
-	for i := range result.Contents {
-		file := *result.Contents[i].Key
-		fmt.Printf("%s \t %s \n", bytesize.New(float64((*result.Contents[i].Size))), file[strings.Index(file, "/")+1:])
+	for i := range result {
+		file := *result[i].Key
+		fmt.Printf("%s \t %s \n", bytesize.New(float64((*result[i].Size))), file[strings.Index(file, "/")+1:])
 	}
 
 	return nil

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -158,7 +158,7 @@ func uploadFiles(files, outFiles []string, targetDir string, config *helpers.Con
 				listPrefix = targetDir + "/" + outFiles[k]
 			}
 
-			listResult, err := helpers.ListFiles(*config, listPrefix)
+			listResult, err := helpers.ListFiles(*config, listPrefix, -1)
 			if err != nil {
 				return fmt.Errorf("listing uploaded files: %s", err.Error())
 			}

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -158,7 +158,7 @@ func uploadFiles(files, outFiles []string, targetDir string, config *helpers.Con
 				listPrefix = targetDir + "/" + outFiles[k]
 			}
 
-			listResult, err := helpers.ListFiles(*config, listPrefix, -1)
+			listResult, err := helpers.ListFiles(*config, listPrefix)
 			if err != nil {
 				return fmt.Errorf("listing uploaded files: %s", err.Error())
 			}

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -163,7 +163,7 @@ func uploadFiles(files, outFiles []string, targetDir string, config *helpers.Con
 				return fmt.Errorf("listing uploaded files: %s", err.Error())
 			}
 
-			fileExists := len(listResult.Contents) > 0 && aws.StringValue(listResult.Contents[0].Key) == filepath.Clean(config.AccessKey+"/"+listPrefix)
+			fileExists := len(listResult) > 0 && aws.StringValue(listResult[0].Key) == filepath.Clean(config.AccessKey+"/"+listPrefix)
 			switch {
 			case fileExists && *continueUpload:
 				fmt.Printf("File %s has already been uploaded, continuing with the next file...\n", filepath.Base(filename))


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #502 .

**Description**

- Overall functionality remains unchanged but now the `ListFiles` function checks to see if there are more than the returned results and makes subsequent calls until it retrieves all the object info.
 - Added unit tests for `ListFiles` function (which were missing) along with tests for list pagination 

**How to test**
Easy way: run `go test ./helpers` 
Other way: Upload 1001 files in a bucket and try to list with sda-cli