### PR TITLE
fix: show current version

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -99,15 +99,17 @@ func Version(ver string) error {
 		return nil
 	}
 
-	fmt.Println("sda-cli version: ", ver)
-
 	if appVer.LessThan(ghVer) {
 		pt, _ := time.Parse(time.RFC3339, ghVersion.Published)
+		fmt.Printf("Current sda-cli version: %v \n\n", ver)
 		fmt.Printf("Newer version of sda-cli is available, %s\n", ghVersion.Name)
 		fmt.Printf("Published: %s\n", pt.Format(time.DateTime))
 		fmt.Printf("Download it from here: %s\n", ghVersion.URL)
 
+		return nil
 	}
+
+	fmt.Println("sda-cli version: ", ver)
 
 	return nil
 }

--- a/version/version.go
+++ b/version/version.go
@@ -99,16 +99,15 @@ func Version(ver string) error {
 		return nil
 	}
 
+	fmt.Println("sda-cli version: ", ver)
+
 	if appVer.LessThan(ghVer) {
 		pt, _ := time.Parse(time.RFC3339, ghVersion.Published)
 		fmt.Printf("Newer version of sda-cli is available, %s\n", ghVersion.Name)
 		fmt.Printf("Published: %s\n", pt.Format(time.DateTime))
 		fmt.Printf("Download it from here: %s\n", ghVersion.URL)
 
-		return nil
 	}
-
-	fmt.Println("sda-cli version: ", ver)
 
 	return nil
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -28,8 +28,17 @@ func (suite *VersionTests) TestGetVersion() {
 	defer mockServer.Close()
 	url = mockServer.URL
 
+	storeStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
 	err := Version("1.0.0")
 	assert.NoError(suite.T(), err)
+
+	w.Close()
+	out, _ := io.ReadAll(r)
+	os.Stdout = storeStdout
+	assert.Contains(suite.T(), string(out), "version:  1.0.0")
 }
 
 func (suite *VersionTests) TestGetVersion_newerAvailable() {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #524 

**Description**
Now prints:
```
$ sda-cli version
Current sda-cli version:  v0.1.4

Newer version of sda-cli is available, v0.1.5
Published: 2025-03-13 10:20:42
Download it from here: https://github.com/NBISweden/sda-cli/releases/tag/v0.1.5
```
Or, for the latest version:
```
$ sda-cli version
sda-cli version:  v0.1.5
```

**How to test**
```
$ go build
$ ./sda-cli version
```
Also see new unit test.