### PR TITLE
fix: report when subcommand is missing

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,6 +134,11 @@ func ParseArgs() (string, []string, string) {
 
 	// Extract the command from the 1st argument, then remove it
 	// from list of arguments.
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Error: no command given\n")
+		os.Exit(1)
+
+	}
 	command := os.Args[1]
 	os.Args = append(os.Args[:1], os.Args[2:]...)
 

--- a/main.go
+++ b/main.go
@@ -137,7 +137,6 @@ func ParseArgs() (string, []string, string) {
 	if len(os.Args) < 2 {
 		fmt.Fprintf(os.Stderr, "Error: no command given\n")
 		os.Exit(1)
-
 	}
 	command := os.Args[1]
 	os.Args = append(os.Args[:1], os.Args[2:]...)


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #518 .


**Description**
```
$./sda-cli -config s3cfg 
Error: no command given
```
Note that the term "command" is used, rather than "subcommand", as this is the term we consistently use in the help section:


>  /sda-cli -config s3cfg  help
> Usage: sda-cli [-config <config-file>] <**command**> [OPTIONS]
> 
> A tool for common tasks with the Sensitive Data Archive (SDA)
> 
> **Commands**:
>   createKey   Creates a Crypt4GH key pair
> ...
> 
> Run 'sda-cli help <**command**>' for more information on a command.

**How to test**
Run `sda-cli --config myconfigfil`.
All other commands should work as previously.