### PR TITLE
better error message for config flag

### DIFF
--- a/.github/integration/tests/10_encrypt_decrypt.sh
+++ b/.github/integration/tests/10_encrypt_decrypt.sh
@@ -104,4 +104,16 @@ done
 
 echo "Could decrypt with all keys from concatenated key"
 
+if ./sda-cli decrypt -key $key.sec.pem data_file_keys.c4gh -config  testing/s3cmd.conf 2> >(grep "the config flag should come before the subcommand. Eg 'sda-cli -config s3cfg decrypt" > /dev/null ) -ne 1
+then
+    echo "Unexpected error message"
+    exit 1
+fi
+if ./sda-cli encrypt -key $key.sec.pem data_file_keys.c4gh -config  testing/s3cmd.conf 2> >(grep "the config flag should come before the subcommand. Eg 'sda-cli -config s3cfg encrypt" > /dev/null ) -ne 1
+then
+    echo "Unexpected error message"
+    exit 1
+fi
+
+
 echo "Integration tests for sda-cli encrypt finished successfully"

--- a/.github/integration/tests/20_upload.sh
+++ b/.github/integration/tests/20_upload.sh
@@ -101,4 +101,10 @@ else
     exit 1
 fi
 
+if ./sda-cli upload -targitDir "$uploadDir" -r -config  testing/s3cmd.conf 2> >(grep "the config flag should come before the subcommand. Eg 'sda-cli -config s3cfg upload" > /dev/null ) -ne 1
+then
+    echo "Unexpected error message"
+    exit 1
+fi
+
 echo "Integration tests for sda-cli upload finished successfully"

--- a/.github/integration/tests/30_list.sh
+++ b/.github/integration/tests/30_list.sh
@@ -30,4 +30,10 @@ else
     exit 1
 fi
 
+if ./sda-cli list --datasets -url http://localhost:8080 -config  testing/s3cmd.conf 2> >(grep "the config flag should come before the subcommand. Eg 'sda-cli -config s3cfg list" > /dev/null ) -ne 1
+then
+    echo "Unexpected error message"
+    exit 1
+fi
+
 echo "Integration tests for sda-cli list finished successfully"

--- a/.github/integration/tests/40_download.sh
+++ b/.github/integration/tests/40_download.sh
@@ -134,6 +134,12 @@ else
     echo "Error expected, continue."
 fi
 
+if ./sda-cli download -dataset-id https://doi .example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -config  testing/s3cmd.conf 2> >(grep "the config flag should come before the subcommand. Eg 'sda-cli -config s3cfg download" > /dev/null ) -ne 1
+then
+    echo "Unexpected error message"
+    exit 1
+fi
+
 rm -r download-from-file
 rm -r test-download
 

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -35,7 +35,7 @@ Arguments:
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help
-var Args = flag.NewFlagSet("decrypt", flag.ExitOnError)
+var Args = flag.NewFlagSet("decrypt", flag.ContinueOnError)
 
 var privateKeyFile = Args.String("key", "", "Private key to use for decrypting files.")
 var forceOverwrite = Args.Bool("force-overwrite", false, "Force overwrite existing files.")

--- a/download/download.go
+++ b/download/download.go
@@ -59,7 +59,7 @@ Arguments:
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help
-var Args = flag.NewFlagSet("download", flag.ExitOnError)
+var Args = flag.NewFlagSet("download", flag.ContinueOnError)
 
 var datasetID = Args.String("dataset-id", "", "Dataset ID for the file to download.")
 

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -56,7 +56,7 @@ Arguments:
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help
-var Args = flag.NewFlagSet("encrypt", flag.ExitOnError)
+var Args = flag.NewFlagSet("encrypt", flag.ContinueOnError)
 
 var outDir = Args.String("outdir", "",
 	"Output directory for encrypted files.")

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -164,6 +164,11 @@ func ParseArgs(args []string, argFlags *flag.FlagSet) error {
 	pos, args = getPositional(args)
 	// append positional args back at the end of args
 	args = append(args, pos...)
+	for _, item := range args {
+		if item == "-config" || item == "--config" {
+			return fmt.Errorf("the config flag should come before the subcommand. Eg 'sda-cli -config s3cfg %s'", argFlags.Name())
+		}
+	}
 	err := argFlags.Parse(args[1:])
 
 	return err

--- a/htsget/htsget.go
+++ b/htsget/htsget.go
@@ -42,7 +42,7 @@ Optional options:
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help
-var Args = flag.NewFlagSet("htsget", flag.ExitOnError)
+var Args = flag.NewFlagSet("htsget", flag.ContinueOnError)
 var datasetID = Args.String("dataset", "", "Dataset ID for the file to download")
 var fileName = Args.String("filename", "", "The name of the file to download")
 var referenceName = Args.String("reference", "", "The reference number of the file to download")

--- a/list/list.go
+++ b/list/list.go
@@ -41,7 +41,7 @@ Arguments:
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help
-var Args = flag.NewFlagSet("list", flag.ExitOnError)
+var Args = flag.NewFlagSet("list", flag.ContinueOnError)
 
 var URL = Args.String("url", "", "The url of the sda-download server")
 

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -60,7 +60,7 @@ Arguments:
 
 // Args is a flagset that needs to be exported so that it can be written to the
 // main program help
-var Args = flag.NewFlagSet("upload", flag.ExitOnError)
+var Args = flag.NewFlagSet("upload", flag.ContinueOnError)
 
 var forceUnencrypted = Args.Bool("force-unencrypted", false, "Force uploading unencrypted files.")
 


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #533 


**Description**
The current output looks like this
```
$ ./sda-cli  upload katt.txt.c4gh -config /tmp/shared/s3cfg 
Error: failed parsing arguments, reason: the config flag should come before the subcommand. Eg 'sda-cli -config s3cfg upload'
```

If you wonder about the implementation:
- 89873c4d2ba97b74e22ea6d8874327320c0fdbe7  fixes the problematic behavior. Unfortunately, in a not supernice way (code wise). The `flag` package insists on printing it's own error (`flag provided but not defined: -config`) and then all the help messages about the current subcommand, before you can make it print the error you want:
    ```
    ./sda-cli  upload ../sensitive-data-anchive/katt.txt.c4gh -config /tmp/shared/s3cfg 
    flag provided but not defined: -config
    Usage of upload:
      -accessToken ACCESSTOKEN
    
    ...
    
    Error: failed parsing arguments, reason: the config flag should come before the 
    subcommand. Eg 'sda-cli -config s3cfg upload'
    ```
   Therefore, the current solution checks the args before they are parsed.

- 2652a5d413921099bd832633e0343fdd1dd725c1 is not actually doing anything for this solution, but `ContinueOnError` is the correct flag to use if you want the [calling function of `Parse`](https://github.com/NBISweden/sda-cli/blob/5d978f687304bb640999bf02d643489e73934f14/helpers/helpers.go#L172) to be able to see the error produced.

- 5d978f687304bb640999bf02d643489e73934f14 adds tests.

**How to test**
Try the different subcommands, with the config flag given after the subcommand:
```
$ ./sda-cli  upload katt.txt.c4gh -config /tmp/shared/s3cfg 
Error: failed parsing arguments, reason: the config flag should come before the subcommand. Eg 'sda-cli -config s3cfg upload'
```

```
$./sda-cli list --datasets -url http://localhost:8080 -config  testing/s3cmd.conf
Error: failed parsing arguments, reason: the config flag should come before the subcommand. Eg 'sda-cli -config s3cfg list'
```

