### PR TITLE
Feature/download resume dataset

### DIFF
--- a/.github/integration/tests/40_download.sh
+++ b/.github/integration/tests/40_download.sh
@@ -41,6 +41,26 @@ for filepath in $filepaths; do
     fi
 done
 
+# Try to download files again using the -continue flag
+testContinue=$(./sda-cli -config testing/s3cmd-download.conf download -pubkey user_key.pub.pem  -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-dataset --dataset -continue | grep -c Skipping)
+
+# Check if all existing files were skipped
+if  [ "$testContinue" -ne 3 ]; then
+    echo "Failed to skip already existing files when using the -continue flag"
+    exit 1
+fi
+
+# Remove one file and try to download dataset again using the -continue flag
+testContinueFilePath=download-dataset/main/subfolder/dummy_data.c4gh
+rm "$testContinueFilePath"
+testContinue=$(./sda-cli -config testing/s3cmd-download.conf download -pubkey user_key.pub.pem  -dataset-id https://doi.example/ty009.sfrrss/600.45asasga -url http://localhost:8080 -outdir download-dataset --dataset -continue | grep -c Skipping)
+
+# Check that only the existing files were skipped and the non-existing file was downloaded
+if  [ "$testContinue" -ne 2 ] || [ ! -f "$testContinueFilePath" ]; then
+    echo "Failed to download non-existing file when using the -continue flag"
+    exit 1
+fi
+
 rm -r download-dataset
 
 # Download encrypted file by using the sda-cli download command

--- a/download/download.go
+++ b/download/download.go
@@ -45,6 +45,7 @@ Required options:
   -url <uri>                  The url of the download server.
 
 Optional options:
+  -continue                   Skip already downloaded files and continue with downloading the rest.
   -pubkey <public-key-file>   Key to use for encrypting downloaded files server-side.
                               This key must be given here or in the config file.
   -outdir <dir>               Directory to save the downloaded files.
@@ -77,6 +78,8 @@ var recursiveDownload = Args.Bool("recursive", false, "Download content of the f
 var fromFile = Args.Bool("from-file", false, "Download files from file list.")
 
 var pubKeyBase64 string
+
+var continueDownload = Args.Bool("continue", false, "Skip existing files and continue with the rest.")
 
 // necessary for mocking in testing
 var getResponseBody = getBody
@@ -327,6 +330,15 @@ func downloadFile(uri, token, pubKeyBase64, filePath string) error {
 	if pubKeyBase64 != "" {
 		filePath += ".c4gh"
 	}
+
+	if *continueDownload {
+		if _, err := os.Stat(filePath); !errors.Is(err, os.ErrNotExist) {
+			fmt.Printf("Skipping download to %s, file already exists\n", filePath)
+
+			return nil
+		}
+	}
+
 	outfile, err := os.Create(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to create file, reason: %v", err)


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #405.

**Description**

If the flag `-continue` is given to `download` then any existing file with the same name and file path will be skipped during download.

**How to test**
See that the added integration tests pass.