### PR TITLE
Feature/unify log output (#455)

### DIFF
--- a/create_key/create_key.go
+++ b/create_key/create_key.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/NBISweden/sda-cli/helpers"
 	"github.com/neicnordic/crypt4gh/keys"
-	log "github.com/sirupsen/logrus"
 )
 
 // Usage text that will be displayed when the `help createKey` command is invoked.
@@ -88,7 +87,7 @@ func GenerateKeyPair(basename, password string) error {
 	}
 
 	// Generate key pair
-	log.Infof("Generating key pair: %s, %s", privateKeyName, publicKeyName)
+	fmt.Printf("Generating key pair: %s, %s\n", privateKeyName, publicKeyName)
 
 	publicKeyData, privateKeyData, err := keys.GenerateKeyPair()
 	if err != nil {
@@ -102,7 +101,7 @@ func GenerateKeyPair(basename, password string) error {
 	}
 	defer func() {
 		if err := pubFile.Close(); err != nil {
-			log.Errorf("Error closing file: %s\n", err)
+			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
 		}
 	}()
 	err = keys.WriteCrypt4GHX25519PublicKey(pubFile, publicKeyData)
@@ -116,7 +115,7 @@ func GenerateKeyPair(basename, password string) error {
 	}
 	defer func() {
 		if err := secFile.Close(); err != nil {
-			log.Errorf("Error closing file: %s\n", err)
+			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
 		}
 	}()
 	err = keys.WriteCrypt4GHX25519PrivateKey(secFile, privateKeyData, []byte(password))

--- a/create_key/create_key.go
+++ b/create_key/create_key.go
@@ -46,7 +46,7 @@ func CreateKey(args []string) error {
 	// we check for them.
 	err := Args.Parse(args[1:])
 	if err != nil {
-		return fmt.Errorf("could not parse arguments: %s", err)
+		return fmt.Errorf("could not parse arguments: %v", err)
 	}
 
 	// Args() returns the non-flag arguments, which we assume is the key
@@ -101,7 +101,7 @@ func GenerateKeyPair(basename, password string) error {
 	}
 	defer func() {
 		if err := pubFile.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
+			fmt.Fprintf(os.Stderr, "Error closing file: %v\n", err)
 		}
 	}()
 	err = keys.WriteCrypt4GHX25519PublicKey(pubFile, publicKeyData)
@@ -115,7 +115,7 @@ func GenerateKeyPair(basename, password string) error {
 	}
 	defer func() {
 		if err := secFile.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
+			fmt.Fprintf(os.Stderr, "Error closing file: %v\n", err)
 		}
 	}()
 	err = keys.WriteCrypt4GHX25519PrivateKey(secFile, privateKeyData, []byte(password))

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -112,7 +112,7 @@ func Decrypt(args []string) error {
 		if *clean {
 			err = os.Remove(file.Encrypted)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Could not remove encrypted file %s: %s\n", file.Encrypted, err)
+				fmt.Fprintf(os.Stderr, "Could not remove encrypted file %s: %v\n", file.Encrypted, err)
 
 				continue
 			}
@@ -163,7 +163,7 @@ func decryptFile(filename, outfileName string, privateKey [32]byte) error {
 	// Create crypt4gh reader
 	crypt4GHReader, err := streaming.NewCrypt4GHReader(inFile, privateKey, nil)
 	if err != nil {
-		return fmt.Errorf("could not create cryp4gh reader: %s", err)
+		return fmt.Errorf("could not create cryp4gh reader: %v", err)
 	}
 
 	// open output file for writing

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -1,7 +1,6 @@
 package download
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"log"
 )
 
 type TestSuite struct {
@@ -43,13 +41,14 @@ func createConfigFile(fileName, token string) os.File {
 	// Create config file
 	configPath, err := os.CreateTemp(os.TempDir(), fileName)
 	if err != nil {
-		log.Panic(err)
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 
 	// Write config file
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		log.Printf("failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
 	}
 
 	return *configPath
@@ -95,10 +94,6 @@ func (suite *TestSuite) TestPrintHostBase() {
 		"https://some/url",
 		"file1",
 	}
-
-	var str bytes.Buffer
-	log.SetOutput(&str)
-	defer log.SetOutput(os.Stdout)
 
 	// check if the host_base is in the error output
 	rescueStderr := os.Stderr

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -10,10 +10,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"log"
 )
 
 type TestSuite struct {

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -41,14 +41,14 @@ func createConfigFile(fileName, token string) os.File {
 	// Create config file
 	configPath, err := os.CreateTemp(os.TempDir(), fileName)
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 
 	// Write config file
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
 	}
 
 	return *configPath

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -19,7 +19,7 @@ type TestSuite struct {
 	accessToken string
 }
 
-func createConfigFile(fileName, token string) os.File {
+func (suite *TestSuite) createConfigFile(fileName, token string) os.File {
 	// Create conf file for sda-cli
 	confFile := fmt.Sprintf(`
 	access_token = %[1]s
@@ -41,14 +41,13 @@ func createConfigFile(fileName, token string) os.File {
 	// Create config file
 	configPath, err := os.CreateTemp(os.TempDir(), fileName)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to create temp test config file", err)
 	}
 
 	// Write config file
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
+		suite.FailNow("failed to write temp config file", err)
 	}
 
 	return *configPath
@@ -63,7 +62,7 @@ func (suite *TestSuite) SetupTest() {
 }
 
 func (suite *TestSuite) TestInvalidUrl() {
-	confPath := createConfigFile("s3cmd.conf", suite.accessToken)
+	confPath := suite.createConfigFile("s3cmd.conf", suite.accessToken)
 
 	os.Args = []string{
 		"download",
@@ -84,7 +83,7 @@ func (suite *TestSuite) TestInvalidUrl() {
 }
 
 func (suite *TestSuite) TestPrintHostBase() {
-	confPath := createConfigFile("s3cmd.conf", suite.accessToken)
+	confPath := suite.createConfigFile("s3cmd.conf", suite.accessToken)
 
 	os.Args = []string{
 		"download",

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -101,7 +101,7 @@ func (suite *TestSuite) TestPrintHostBase() {
 
 	_ = Download(os.Args, confPath.Name())
 
-	w.Close() //nolint:errcheck
+	_ = w.Close()
 	os.Stderr = rescueStderr
 	uploadError, _ := io.ReadAll(r)
 

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -161,7 +161,7 @@ func Encrypt(args []string) error {
 
 		// Skip files that do not pass the checks and print all error logs at the end
 		if err = checkFiles(eachFile); err != nil {
-			defer fmt.Fprintf(os.Stderr, "Skipping input file %s. Reason: %s.\n", filename, err)
+			defer fmt.Fprintf(os.Stderr, "Skipping input file %s. Reason: %v.\n", filename, err)
 			if !*continueEncrypt {
 				return fmt.Errorf("aborting")
 			}
@@ -193,7 +193,7 @@ func Encrypt(args []string) error {
 	}
 	defer func() {
 		if err := checksumFileUnencMd5.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
+			fmt.Fprintf(os.Stderr, "Error closing file: %v\n", err)
 		}
 	}()
 
@@ -203,7 +203,7 @@ func Encrypt(args []string) error {
 	}
 	defer func() {
 		if err := checksumFileUnencSha256.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
+			fmt.Fprintf(os.Stderr, "Error closing file: %v\n", err)
 		}
 	}()
 
@@ -213,7 +213,7 @@ func Encrypt(args []string) error {
 	}
 	defer func() {
 		if err := checksumFileEncMd5.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
+			fmt.Fprintf(os.Stderr, "Error closing file: %v\n", err)
 		}
 	}()
 
@@ -223,7 +223,7 @@ func Encrypt(args []string) error {
 	}
 	defer func() {
 		if err := checksumFileEncSha256.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
+			fmt.Fprintf(os.Stderr, "Error closing file: %v\n", err)
 		}
 	}()
 
@@ -285,7 +285,7 @@ func checkFiles(files []helpers.EncryptionFileSet) error {
 		}
 		defer func() {
 			if err := unEncryptedFile.Close(); err != nil {
-				fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
+				fmt.Fprintf(os.Stderr, "Error closing file: %v\n", err)
 			}
 		}()
 
@@ -314,7 +314,7 @@ func calculateHashes(fileSet helpers.EncryptionFileSet) (*hashSet, error) {
 	}
 	defer func() {
 		if err := unencryptedFile.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
+			fmt.Fprintf(os.Stderr, "Error closing file: %v\n", err)
 		}
 	}()
 
@@ -338,7 +338,7 @@ func calculateHashes(fileSet helpers.EncryptionFileSet) (*hashSet, error) {
 	}
 	defer func() {
 		if err := encryptedFile.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
+			fmt.Fprintf(os.Stderr, "Error closing file: %v\n", err)
 		}
 	}()
 
@@ -435,7 +435,7 @@ func encrypt(filename, outFilename string, pubKeyList [][32]byte, privateKey [32
 	}
 	defer func() {
 		if err := inFile.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
+			fmt.Fprintf(os.Stderr, "Error closing file: %v\n", err)
 		}
 	}()
 
@@ -446,7 +446,7 @@ func encrypt(filename, outFilename string, pubKeyList [][32]byte, privateKey [32
 	}
 	defer func() {
 		if err := outFile.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
+			fmt.Fprintf(os.Stderr, "Error closing file: %v\n", err)
 		}
 	}()
 
@@ -496,7 +496,7 @@ func checkKeyFile(pubkey string, k keySpecs) (int64, error) {
 	}
 	defer func() {
 		if err := f.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
+			fmt.Fprintf(os.Stderr, "Error closing file: %v\n", err)
 		}
 	}()
 

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -230,7 +230,7 @@ func Encrypt(args []string) error {
 	// encrypt the input files
 	numFiles := len(files)
 	for i, file := range files {
-		fmt.Fprintf(os.Stderr, "Encrypting file %v/%v: %s\n", i+1, numFiles, file.Unencrypted)
+		fmt.Printf("Encrypting file %v/%v: %s\n", i+1, numFiles, file.Unencrypted)
 
 		// encrypt the file
 		err = encrypt(file.Unencrypted, file.Encrypted, pubKeyList, *privateKey)

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -482,6 +482,8 @@ func encrypt(filename, outFilename string, pubKeyList [][32]byte, privateKey [32
 		return err
 	}
 
+	p.Wait()
+
 	return nil
 }
 

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -230,7 +230,7 @@ func Encrypt(args []string) error {
 	// encrypt the input files
 	numFiles := len(files)
 	for i, file := range files {
-		fmt.Fprintf(os.Stderr, "Encrypting file %v/%v: %s", i+1, numFiles, file.Unencrypted)
+		fmt.Fprintf(os.Stderr, "Encrypting file %v/%v: %s\n", i+1, numFiles, file.Unencrypted)
 
 		// encrypt the file
 		err = encrypt(file.Unencrypted, file.Encrypted, pubKeyList, *privateKey)

--- a/encrypt/encrypt_test.go
+++ b/encrypt/encrypt_test.go
@@ -44,39 +44,39 @@ func (suite *EncryptTests) SetupTest() {
 	// Generate a crypt4gh key pair
 	suite.pubKeyData, suite.secKeyData, err = keys.GenerateKeyPair()
 	if err != nil {
-		fmt.Fprint(os.Stderr, "Couldn't generate key pair", err)
+		fmt.Fprintln(os.Stderr, "Couldn't generate key pair", err)
 		os.Exit(1)
 	}
 
 	// Create a temporary directory for our files
 	suite.tempDir, err = os.MkdirTemp(os.TempDir(), "sda-cli-test-")
 	if err != nil {
-		fmt.Fprint(os.Stderr, "Couldn't create temporary test directory", err)
+		fmt.Fprintln(os.Stderr, "Couldn't create temporary test directory", err)
 		os.Exit(1)
 	}
 
 	// Write the keys to temporary files
 	suite.publicKey, err = os.CreateTemp(suite.tempDir, "pubkey-")
 	if err != nil {
-		fmt.Fprint(os.Stderr, "Cannot create temporary public key file", err)
+		fmt.Fprintln(os.Stderr, "Cannot create temporary public key file", err)
 		os.Exit(1)
 	}
 
 	err = keys.WriteCrypt4GHX25519PublicKey(suite.publicKey, suite.pubKeyData)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temporary public key file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temporary public key file, %v\n", err)
 		os.Exit(1)
 	}
 
 	suite.privateKey, err = os.CreateTemp(suite.tempDir, "seckey-")
 	if err != nil {
-		fmt.Fprint(os.Stderr, "cannot create temporary private key file", err)
+		fmt.Fprintln(os.Stderr, "cannot create temporary private key file", err)
 		os.Exit(1)
 	}
 
 	err = keys.WriteCrypt4GHX25519PrivateKey(suite.privateKey, suite.secKeyData, []byte(""))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temporary private key file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temporary private key file, %v\n", err)
 		os.Exit(1)
 	}
 
@@ -84,52 +84,52 @@ func (suite *EncryptTests) SetupTest() {
 	// Append same key twice. Works until we decide that we do not allow duplicates.
 	suite.multiPublicKey, err = os.CreateTemp(suite.tempDir, "pubkey-")
 	if err != nil {
-		fmt.Fprint(os.Stderr, "Cannot create temporary public key file", err)
+		fmt.Fprintln(os.Stderr, "Cannot create temporary public key file", err)
 		os.Exit(1)
 	}
 
 	input, err := os.ReadFile(suite.publicKey.Name())
 	if err != nil {
-		fmt.Fprint(os.Stderr, "Cannot read from public key file", err)
+		fmt.Fprintln(os.Stderr, "Cannot read from public key file", err)
 		os.Exit(1)
 	}
 
 	err = os.WriteFile(suite.multiPublicKey.Name(), append(input, input...), 0600)
 	if err != nil {
-		fmt.Fprint(os.Stderr, "cannot write to temporary multi-key file", err)
+		fmt.Fprintln(os.Stderr, "cannot write to temporary multi-key file", err)
 		os.Exit(1)
 	}
 
 	// create an existing test file with some known content
 	suite.fileOk, err = os.CreateTemp(suite.tempDir, "testfile-")
 	if err != nil {
-		fmt.Fprint(os.Stderr, "cannot create temporary public key file", err)
+		fmt.Fprintln(os.Stderr, "cannot create temporary public key file", err)
 		os.Exit(1)
 	}
 
 	err = os.WriteFile(suite.fileOk.Name(), []byte("content"), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write to testfile: %s", err)
+		fmt.Fprintf(os.Stderr, "failed to write to testfile: %s\n", err)
 		os.Exit(1)
 	}
 
 	// create an existing encrypted test file
 	suite.encryptedFile, err = os.CreateTemp(suite.tempDir, "encrypted-input")
 	if err != nil {
-		fmt.Fprint(os.Stderr, "cannot create temporary encrypted testfile", err)
+		fmt.Fprintln(os.Stderr, "cannot create temporary encrypted testfile", err)
 		os.Exit(1)
 	}
 
 	err = os.WriteFile(suite.encryptedFile.Name(), []byte("crypt4gh"), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write to temporary encrypted testfile: %s", err)
+		fmt.Fprintf(os.Stderr, "failed to write to temporary encrypted testfile: %s\n", err)
 		os.Exit(1)
 	}
 
 	// create an large test file with some known content
 	suite.largeFile, err = os.CreateTemp(suite.tempDir, "largefile-")
 	if err != nil {
-		fmt.Fprint(os.Stderr, "cannot create temporary test file", err)
+		fmt.Fprintln(os.Stderr, "cannot create temporary test file", err)
 		os.Exit(1)
 	}
 
@@ -173,7 +173,7 @@ func (suite *EncryptTests) TestcheckFiles() {
 func (suite *EncryptTests) TestreadPublicKeyFile() {
 	file, err := os.Open(suite.publicKey.Name())
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	defer file.Close() //nolint:errcheck

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/johannesboyne/gofakes3 v0.0.0-20220627085814-c3ac35da23b2
 	github.com/manifoldco/promptui v0.9.0
 	github.com/neicnordic/crypt4gh v1.14.0
-	github.com/sirupsen/logrus v1.9.3
 	github.com/smallnest/ringbuffer v0.0.0-20250317021400-0da97b586904
 	github.com/stretchr/testify v1.10.0
 	github.com/vbauerster/mpb/v8 v8.10.2

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -53,7 +53,7 @@ func FileIsReadable(filename string) bool {
 	}
 	defer func() {
 		if err := inFile.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
+			fmt.Fprintf(os.Stderr, "Error closing file: %v\n", err)
 		}
 	}()
 
@@ -311,7 +311,7 @@ func CreatePubFile(publicKey string, filename string) (string, error) {
 	defer func() {
 		// Close the file and log any error that may occur
 		if cerr := pubFile.Close(); cerr != nil {
-			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", cerr)
+			fmt.Fprintf(os.Stderr, "Error closing file: %v\n", cerr)
 		}
 	}()
 	// Write the publicKeyData array to the "key-from-oidc.pub.pem" file in Crypt4GHX25519 public key format
@@ -329,7 +329,7 @@ func CheckTokenExpiration(accessToken string) error {
 	// Parse jwt token with unverifies, since we don't need to check the signatures here
 	token, _, err := new(jwt.Parser).ParseUnverified(accessToken, jwt.MapClaims{})
 	if err != nil {
-		return fmt.Errorf("could not parse token, reason: %s", err)
+		return fmt.Errorf("could not parse token, reason: %v", err)
 	}
 
 	claims, ok := token.Claims.(jwt.MapClaims)
@@ -354,7 +354,7 @@ func CheckTokenExpiration(accessToken string) error {
 	case string:
 		i, err := strconv.ParseInt(iat, 10, 64)
 		if err != nil {
-			return fmt.Errorf("could not parse token, reason: %s", err)
+			return fmt.Errorf("could not parse token, reason: %v", err)
 		}
 		expiration = time.Unix(int64(i), 0)
 	default:

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -23,7 +23,6 @@ import (
 	"github.com/golang-jwt/jwt"
 	"github.com/manifoldco/promptui"
 	"github.com/neicnordic/crypt4gh/keys"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
 	"gopkg.in/ini.v1"
 )
@@ -54,7 +53,7 @@ func FileIsReadable(filename string) bool {
 	}
 	defer func() {
 		if err := inFile.Close(); err != nil {
-			log.Errorf("Error closing file: %s\n", err)
+			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
 		}
 	}()
 
@@ -312,7 +311,7 @@ func CreatePubFile(publicKey string, filename string) (string, error) {
 	defer func() {
 		// Close the file and log any error that may occur
 		if cerr := pubFile.Close(); cerr != nil {
-			log.Errorf("Error closing file: %s\n", cerr)
+			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", cerr)
 		}
 	}()
 	// Write the publicKeyData array to the "key-from-oidc.pub.pem" file in Crypt4GHX25519 public key format

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rsa"
 	"fmt"
 	"io"
-	"log"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -38,7 +37,8 @@ func generateDummyToken(expDate int64) string {
 	// Generate a new private key
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		log.Fatalf("Failed to generate private key: %s", err)
+		fmt.Fprintf(os.Stderr, "Failed to generate private key: %s", err)
+		os.Exit(1)
 	}
 
 	// Create the Claims
@@ -55,7 +55,8 @@ func generateDummyToken(expDate int64) string {
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 	ss, err := token.SignedString(privateKey)
 	if err != nil {
-		log.Fatalf("Failed to sign token: %s", err)
+		fmt.Fprintf(os.Stderr, "Failed to sign token: %s", err)
+		os.Exit(1)
 	}
 
 	return ss
@@ -72,29 +73,34 @@ func (suite *HelperTests) SetupTest() {
 	// Create a temporary directory for our files
 	suite.tempDir, err = os.MkdirTemp(os.TempDir(), "sda-cli-test-")
 	if err != nil {
-		log.Fatal("Couldn't create temporary test directory", err)
+		fmt.Fprint(os.Stderr, "Couldn't create temporary test directory", err)
+		os.Exit(1)
 	}
 
 	// create an existing test file with some known content
 	suite.testFile, err = os.CreateTemp(suite.tempDir, "testfile-")
 	if err != nil {
-		log.Fatal("cannot create temporary file", err)
+		fmt.Fprint(os.Stderr, "cannot create temporary file", err)
+		os.Exit(1)
 	}
 
 	err = os.WriteFile(suite.testFile.Name(), []byte("content"), 0600)
 	if err != nil {
-		log.Fatalf("failed to write to testfile: %s", err)
+		fmt.Fprintf(os.Stderr, "failed to write to testfile: %s", err)
+		os.Exit(1)
 	}
 
 	// create another existing test file with some known content
 	suite.testFile1, err = os.CreateTemp(suite.tempDir, "testfile-")
 	if err != nil {
-		log.Fatal("cannot create temporary file", err)
+		fmt.Fprint(os.Stderr, "cannot create temporary file", err)
+		os.Exit(1)
 	}
 
 	err = os.WriteFile(suite.testFile1.Name(), []byte("more content"), 0600)
 	if err != nil {
-		log.Fatalf("failed to write to testfile1: %s", err)
+		fmt.Fprintf(os.Stderr, "failed to write to testfile1: %s", err)
+		os.Exit(1)
 	}
 
 	suite.accessToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImtleXN0b3JlLUNIQU5HRS1NRSJ9.eyJqdGkiOiJWTWpfNjhhcEMxR2FJbXRZdFExQ0ciLCJzdWIiOiJkdW1teSIsImlzcyI6Imh0dHA6Ly9vaWRjOjkwOTAiLCJpYXQiOjE3MDc3NjMyODksImV4cCI6MTg2NTU0NzkxOSwic2NvcGUiOiJvcGVuaWQgZ2E0Z2hfcGFzc3BvcnRfdjEgcHJvZmlsZSBlbWFpbCIsImF1ZCI6IlhDNTZFTDExeHgifQ.ZFfIAOGeM2I5cvqr1qJV74qU65appYjpNJVWevGHjGA5Xk_qoRMFJXmG6AiQnYdMKnJ58sYGNjWgs2_RGyw5NyM3-pgP7EKHdWU4PrDOU84Kosg4IPMSFxbBRAEjR5X04YX_CLYW2MFk_OyM9TIln522_JBVT_jA5WTTHSmBRHntVArYYHvQdF-oFRiqL8JXWlsUBh3tqQ33sZdqd9g64YhTk9a5lEC42gn5Hg9Hm_qvkl5orzEqIg7x9z5706IBE4Zypco5ohrAKsEbA8EKbEBb0jigGgCslQNde2owUyKIkvZYmxHA78X5xpymMp9K--PgbkyMS9GtA-YwOHPs-w"
@@ -136,7 +142,8 @@ func (suite *HelperTests) TestFileIsReadable() {
 	if runtime.GOOS != "windows" {
 		err := os.Chmod(suite.testFile.Name(), 0000)
 		if err != nil {
-			log.Fatal("Couldn't set file permissions of test file")
+			fmt.Fprint(os.Stderr, "Couldn't set file permissions of test file")
+			os.Exit(1)
 		}
 		// file permissions don't allow reading
 		testDisallowed := FileIsReadable(suite.testFile.Name())
@@ -145,7 +152,8 @@ func (suite *HelperTests) TestFileIsReadable() {
 		// restore permissions
 		err = os.Chmod(suite.testFile.Name(), 0600)
 		if err != nil {
-			log.Fatal("Couldn't restore file permissions of test file")
+			fmt.Fprint(os.Stderr, "Couldn't restore file permissions of test file")
+			os.Exit(1)
 		}
 	}
 }
@@ -233,14 +241,15 @@ encrypt = False
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd-")
 	if err != nil {
-		log.Fatal(err)
+		fmt.Fprint(os.Stderr, err)
+		os.Exit(1)
 	}
 
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		log.Printf("failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
 	}
 
 	_, err = LoadConfigFile(configPath.Name())
@@ -259,14 +268,15 @@ func (suite *HelperTests) TestConfigS3cmdFileFormat() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd-")
 	if err != nil {
-		log.Fatal(err)
+		fmt.Fprint(os.Stderr, err)
+		os.Exit(1)
 	}
 
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		log.Printf("failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
 	}
 
 	_, err = LoadConfigFile(configPath.Name())
@@ -277,7 +287,8 @@ func (suite *HelperTests) TestConfigMissingCredentials() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd-")
 	if err != nil {
-		log.Fatal(err)
+		fmt.Fprint(os.Stderr, err)
+		os.Exit(1)
 	}
 
 	defer os.Remove(configPath.Name()) //nolint:errcheck
@@ -293,13 +304,14 @@ access_key = someUser
 `
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd-")
 	if err != nil {
-		log.Fatal(err)
+		fmt.Fprint(os.Stderr, err)
+		os.Exit(1)
 	}
 
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	if err := os.WriteFile(configPath.Name(), []byte(confFile), 0600); err != nil {
-		log.Printf("failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
 	}
 
 	_, err = LoadConfigFile(configPath.Name())
@@ -325,14 +337,15 @@ encrypt = False
 `
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd-")
 	if err != nil {
-		log.Fatal(err)
+		fmt.Fprint(os.Stderr, err)
+		os.Exit(1)
 	}
 
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		log.Printf("failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
 	}
 
 	_, err = LoadConfigFile(configPath.Name())
@@ -405,14 +418,15 @@ encrypt = False
 `
 	configPath, err := os.Create(".sda-cli-session")
 	if err != nil {
-		log.Fatal(err)
+		fmt.Fprint(os.Stderr, err)
+		os.Exit(1)
 	}
 
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		log.Printf("failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
 	}
 
 	_, err = GetPublicKeyFromSession()
@@ -440,14 +454,15 @@ public_key = 27be42445fd9e39c9be39e6b36a55e61e3801fc845f63781a813d3fe9977e17a
 `
 	configPath, err := os.Create(".sda-cli-session")
 	if err != nil {
-		log.Fatal(err)
+		fmt.Fprint(os.Stderr, err)
+		os.Exit(1)
 	}
 
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		log.Printf("failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
 	}
 
 	_, err = GetPublicKeyFromSession()
@@ -510,13 +525,15 @@ func (suite *HelperTests) TestListFiles() {
 	}
 	_, err := s3Client.CreateBucket(cparams)
 	if err != nil {
-		log.Panic(err.Error())
+		fmt.Fprint(os.Stderr, err.Error())
+		panic(err.Error())
 	}
 
 	// Upload two test files
 	file, err := os.Open(suite.testFile.Name())
 	if err != nil {
-		log.Panic(err.Error())
+		fmt.Fprint(os.Stderr, err.Error())
+		panic(err.Error())
 	}
 	defer file.Close() //nolint:errcheck
 
@@ -526,12 +543,14 @@ func (suite *HelperTests) TestListFiles() {
 		Body:   file,
 	})
 	if err != nil {
-		log.Panic(err.Error())
+		fmt.Fprint(os.Stderr, err.Error())
+		panic(err.Error())
 	}
 
 	file1, err := os.Open(suite.testFile1.Name())
 	if err != nil {
-		log.Panic(err.Error())
+		fmt.Fprint(os.Stderr, err.Error())
+		panic(err.Error())
 	}
 	defer file1.Close() //nolint:errcheck
 	_, err = s3Client.PutObject(&s3.PutObjectInput{
@@ -540,7 +559,8 @@ func (suite *HelperTests) TestListFiles() {
 		Body:   file1,
 	})
 	if err != nil {
-		log.Panic(err.Error())
+		fmt.Fprint(os.Stderr, err.Error())
+		panic(err.Error())
 	}
 
 	testConfig := &Config{

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -37,7 +37,7 @@ func generateDummyToken(expDate int64) string {
 	// Generate a new private key
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to generate private key: %s", err)
+		fmt.Fprintf(os.Stderr, "Failed to generate private key: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -55,7 +55,7 @@ func generateDummyToken(expDate int64) string {
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 	ss, err := token.SignedString(privateKey)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to sign token: %s", err)
+		fmt.Fprintf(os.Stderr, "Failed to sign token: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -73,33 +73,33 @@ func (suite *HelperTests) SetupTest() {
 	// Create a temporary directory for our files
 	suite.tempDir, err = os.MkdirTemp(os.TempDir(), "sda-cli-test-")
 	if err != nil {
-		fmt.Fprint(os.Stderr, "Couldn't create temporary test directory", err)
+		fmt.Fprintln(os.Stderr, "Couldn't create temporary test directory", err)
 		os.Exit(1)
 	}
 
 	// create an existing test file with some known content
 	suite.testFile, err = os.CreateTemp(suite.tempDir, "testfile-")
 	if err != nil {
-		fmt.Fprint(os.Stderr, "cannot create temporary file", err)
+		fmt.Fprintln(os.Stderr, "cannot create temporary file", err)
 		os.Exit(1)
 	}
 
 	err = os.WriteFile(suite.testFile.Name(), []byte("content"), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write to testfile: %s", err)
+		fmt.Fprintf(os.Stderr, "failed to write to testfile: %s\n", err)
 		os.Exit(1)
 	}
 
 	// create another existing test file with some known content
 	suite.testFile1, err = os.CreateTemp(suite.tempDir, "testfile-")
 	if err != nil {
-		fmt.Fprint(os.Stderr, "cannot create temporary file", err)
+		fmt.Fprintln(os.Stderr, "cannot create temporary file", err)
 		os.Exit(1)
 	}
 
 	err = os.WriteFile(suite.testFile1.Name(), []byte("more content"), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write to testfile1: %s", err)
+		fmt.Fprintf(os.Stderr, "failed to write to testfile1: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -142,7 +142,7 @@ func (suite *HelperTests) TestFileIsReadable() {
 	if runtime.GOOS != "windows" {
 		err := os.Chmod(suite.testFile.Name(), 0000)
 		if err != nil {
-			fmt.Fprint(os.Stderr, "Couldn't set file permissions of test file")
+			fmt.Fprintln(os.Stderr, "Couldn't set file permissions of test file")
 			os.Exit(1)
 		}
 		// file permissions don't allow reading
@@ -152,7 +152,7 @@ func (suite *HelperTests) TestFileIsReadable() {
 		// restore permissions
 		err = os.Chmod(suite.testFile.Name(), 0600)
 		if err != nil {
-			fmt.Fprint(os.Stderr, "Couldn't restore file permissions of test file")
+			fmt.Fprintln(os.Stderr, "Couldn't restore file permissions of test file")
 			os.Exit(1)
 		}
 	}
@@ -241,7 +241,7 @@ encrypt = False
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd-")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -249,7 +249,7 @@ encrypt = False
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
 	}
 
 	_, err = LoadConfigFile(configPath.Name())
@@ -268,7 +268,7 @@ func (suite *HelperTests) TestConfigS3cmdFileFormat() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd-")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -276,7 +276,7 @@ func (suite *HelperTests) TestConfigS3cmdFileFormat() {
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
 	}
 
 	_, err = LoadConfigFile(configPath.Name())
@@ -287,7 +287,7 @@ func (suite *HelperTests) TestConfigMissingCredentials() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd-")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -304,14 +304,14 @@ access_key = someUser
 `
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd-")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	if err := os.WriteFile(configPath.Name(), []byte(confFile), 0600); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
 	}
 
 	_, err = LoadConfigFile(configPath.Name())
@@ -337,7 +337,7 @@ encrypt = False
 `
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd-")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -345,7 +345,7 @@ encrypt = False
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
 	}
 
 	_, err = LoadConfigFile(configPath.Name())
@@ -418,7 +418,7 @@ encrypt = False
 `
 	configPath, err := os.Create(".sda-cli-session")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -426,7 +426,7 @@ encrypt = False
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
 	}
 
 	_, err = GetPublicKeyFromSession()
@@ -454,7 +454,7 @@ public_key = 27be42445fd9e39c9be39e6b36a55e61e3801fc845f63781a813d3fe9977e17a
 `
 	configPath, err := os.Create(".sda-cli-session")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -462,7 +462,7 @@ public_key = 27be42445fd9e39c9be39e6b36a55e61e3801fc845f63781a813d3fe9977e17a
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
 	}
 
 	_, err = GetPublicKeyFromSession()
@@ -525,14 +525,14 @@ func (suite *HelperTests) TestListFiles() {
 	}
 	_, err := s3Client.CreateBucket(cparams)
 	if err != nil {
-		fmt.Fprint(os.Stderr, err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		panic(err.Error())
 	}
 
 	// Upload two test files
 	file, err := os.Open(suite.testFile.Name())
 	if err != nil {
-		fmt.Fprint(os.Stderr, err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		panic(err.Error())
 	}
 	defer file.Close() //nolint:errcheck
@@ -543,13 +543,13 @@ func (suite *HelperTests) TestListFiles() {
 		Body:   file,
 	})
 	if err != nil {
-		fmt.Fprint(os.Stderr, err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		panic(err.Error())
 	}
 
 	file1, err := os.Open(suite.testFile1.Name())
 	if err != nil {
-		fmt.Fprint(os.Stderr, err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		panic(err.Error())
 	}
 	defer file1.Close() //nolint:errcheck
@@ -559,7 +559,7 @@ func (suite *HelperTests) TestListFiles() {
 		Body:   file1,
 	})
 	if err != nil {
-		fmt.Fprint(os.Stderr, err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		panic(err.Error())
 	}
 

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -33,12 +33,11 @@ type HelperTests struct {
 }
 
 // generate jwts for testing the expDate
-func generateDummyToken(expDate int64) string {
+func (suite *HelperTests) generateDummyToken(expDate int64) string {
 	// Generate a new private key
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to generate private key: %s\n", err)
-		os.Exit(1)
+		suite.FailNow("failed to generate key", err)
 	}
 
 	// Create the Claims
@@ -55,8 +54,7 @@ func generateDummyToken(expDate int64) string {
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 	ss, err := token.SignedString(privateKey)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to sign token: %s\n", err)
-		os.Exit(1)
+		suite.FailNow("failed to sign token", err)
 	}
 
 	return ss
@@ -73,34 +71,29 @@ func (suite *HelperTests) SetupTest() {
 	// Create a temporary directory for our files
 	suite.tempDir, err = os.MkdirTemp(os.TempDir(), "sda-cli-test-")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Couldn't create temporary test directory", err)
-		os.Exit(1)
+		suite.FailNow("failed to create temp test directory", err)
 	}
 
 	// create an existing test file with some known content
 	suite.testFile, err = os.CreateTemp(suite.tempDir, "testfile-")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "cannot create temporary file", err)
-		os.Exit(1)
+		suite.FailNow("failed to create temp test file", err)
 	}
 
 	err = os.WriteFile(suite.testFile.Name(), []byte("content"), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write to testfile: %s\n", err)
-		os.Exit(1)
+		suite.FailNow("failed to write to test file", err)
 	}
 
 	// create another existing test file with some known content
 	suite.testFile1, err = os.CreateTemp(suite.tempDir, "testfile-")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "cannot create temporary file", err)
-		os.Exit(1)
+		suite.FailNow("failed to create temp test file", err)
 	}
 
 	err = os.WriteFile(suite.testFile1.Name(), []byte("more content"), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write to testfile1: %s\n", err)
-		os.Exit(1)
+		suite.FailNow("failed to write to test file", err)
 	}
 
 	suite.accessToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImtleXN0b3JlLUNIQU5HRS1NRSJ9.eyJqdGkiOiJWTWpfNjhhcEMxR2FJbXRZdFExQ0ciLCJzdWIiOiJkdW1teSIsImlzcyI6Imh0dHA6Ly9vaWRjOjkwOTAiLCJpYXQiOjE3MDc3NjMyODksImV4cCI6MTg2NTU0NzkxOSwic2NvcGUiOiJvcGVuaWQgZ2E0Z2hfcGFzc3BvcnRfdjEgcHJvZmlsZSBlbWFpbCIsImF1ZCI6IlhDNTZFTDExeHgifQ.ZFfIAOGeM2I5cvqr1qJV74qU65appYjpNJVWevGHjGA5Xk_qoRMFJXmG6AiQnYdMKnJ58sYGNjWgs2_RGyw5NyM3-pgP7EKHdWU4PrDOU84Kosg4IPMSFxbBRAEjR5X04YX_CLYW2MFk_OyM9TIln522_JBVT_jA5WTTHSmBRHntVArYYHvQdF-oFRiqL8JXWlsUBh3tqQ33sZdqd9g64YhTk9a5lEC42gn5Hg9Hm_qvkl5orzEqIg7x9z5706IBE4Zypco5ohrAKsEbA8EKbEBb0jigGgCslQNde2owUyKIkvZYmxHA78X5xpymMp9K--PgbkyMS9GtA-YwOHPs-w"
@@ -142,8 +135,7 @@ func (suite *HelperTests) TestFileIsReadable() {
 	if runtime.GOOS != "windows" {
 		err := os.Chmod(suite.testFile.Name(), 0000)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "Couldn't set file permissions of test file")
-			os.Exit(1)
+			suite.FailNow("failed to chmod test file", err)
 		}
 		// file permissions don't allow reading
 		testDisallowed := FileIsReadable(suite.testFile.Name())
@@ -152,8 +144,7 @@ func (suite *HelperTests) TestFileIsReadable() {
 		// restore permissions
 		err = os.Chmod(suite.testFile.Name(), 0600)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "Couldn't restore file permissions of test file")
-			os.Exit(1)
+			suite.FailNow("failed to chmod test file", err)
 		}
 	}
 }
@@ -241,15 +232,14 @@ encrypt = False
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd-")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		suite.FailNow("failed to create temp s3cmd test file", err)
 	}
 
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
+		suite.FailNow("failed to write config file", err)
 	}
 
 	_, err = LoadConfigFile(configPath.Name())
@@ -268,15 +258,14 @@ func (suite *HelperTests) TestConfigS3cmdFileFormat() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd-")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		suite.FailNow("failed to create temp s3cmd test file", err)
 	}
 
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
+		suite.FailNow("failed to write config file", err)
 	}
 
 	_, err = LoadConfigFile(configPath.Name())
@@ -287,8 +276,7 @@ func (suite *HelperTests) TestConfigMissingCredentials() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd-")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		suite.FailNow("failed to create temp s3cmd test file", err)
 	}
 
 	defer os.Remove(configPath.Name()) //nolint:errcheck
@@ -304,14 +292,13 @@ access_key = someUser
 `
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd-")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		suite.FailNow("failed to create temp s3cmd test file", err)
 	}
 
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	if err := os.WriteFile(configPath.Name(), []byte(confFile), 0600); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
+		suite.FailNow("failed to write to temp s3cmd test file", err)
 	}
 
 	_, err = LoadConfigFile(configPath.Name())
@@ -337,15 +324,14 @@ encrypt = False
 `
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd-")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		suite.FailNow("failed to create temp s3cmd test file", err)
 	}
 
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
+		suite.FailNow("failed to write to temp s3cmd test file", err)
 	}
 
 	_, err = LoadConfigFile(configPath.Name())
@@ -354,17 +340,17 @@ encrypt = False
 
 func (suite *HelperTests) TestTokenExpiration() {
 	// Token without exp claim
-	token := generateDummyToken(0)
+	token := suite.generateDummyToken(0)
 	err := CheckTokenExpiration(token)
 	assert.EqualError(suite.T(), err, "could not parse token, reason: no expiration date")
 
 	// Token with expired date
-	token = generateDummyToken(time.Now().Unix())
+	token = suite.generateDummyToken(time.Now().Unix())
 	err = CheckTokenExpiration(token)
 	assert.EqualError(suite.T(), err, "the provided access token has expired, please renew it")
 
 	// Token with valid expiration, less than 2 hours
-	token = generateDummyToken(time.Now().Add(time.Hour).Unix())
+	token = suite.generateDummyToken(time.Now().Add(time.Hour).Unix())
 
 	storeStderr := os.Stderr
 	r, w, _ := os.Pipe()
@@ -382,7 +368,7 @@ func (suite *HelperTests) TestTokenExpiration() {
 
 	// Token with valid expiration, more than a day
 	exp := time.Now().Add(time.Hour * 72)
-	token = generateDummyToken(exp.Unix())
+	token = suite.generateDummyToken(exp.Unix())
 
 	storeStderr = os.Stderr
 	r, w, _ = os.Pipe()
@@ -418,15 +404,14 @@ encrypt = False
 `
 	configPath, err := os.Create(".sda-cli-session")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		suite.FailNow("failed to create sda cli session test file", err)
 	}
 
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
+		suite.FailNow("failed to write to sda cli session test file", err)
 	}
 
 	_, err = GetPublicKeyFromSession()
@@ -454,15 +439,14 @@ public_key = 27be42445fd9e39c9be39e6b36a55e61e3801fc845f63781a813d3fe9977e17a
 `
 	configPath, err := os.Create(".sda-cli-session")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		suite.FailNow("failed to create sda cli session test file", err)
 	}
 
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
+		suite.FailNow("failed to write to sda cli session test file", err)
 	}
 
 	_, err = GetPublicKeyFromSession()
@@ -525,15 +509,13 @@ func (suite *HelperTests) TestListFiles() {
 	}
 	_, err := s3Client.CreateBucket(cparams)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		panic(err.Error())
+		suite.FailNow("failed to create s3 bucket", err)
 	}
 
 	// Upload two test files
 	file, err := os.Open(suite.testFile.Name())
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		panic(err.Error())
+		suite.FailNow("failed to open test file", err)
 	}
 	defer file.Close() //nolint:errcheck
 
@@ -543,14 +525,12 @@ func (suite *HelperTests) TestListFiles() {
 		Body:   file,
 	})
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		panic(err.Error())
+		suite.FailNow("failed to put test file to s3 bucket", err)
 	}
 
 	file1, err := os.Open(suite.testFile1.Name())
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		panic(err.Error())
+		suite.FailNow("failed to open test file", err)
 	}
 	defer file1.Close() //nolint:errcheck
 	_, err = s3Client.PutObject(&s3.PutObjectInput{
@@ -559,8 +539,7 @@ func (suite *HelperTests) TestListFiles() {
 		Body:   file1,
 	})
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		panic(err.Error())
+		suite.FailNow("failed to put test file to s3 bucket", err)
 	}
 
 	testConfig := &Config{

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -359,7 +359,7 @@ func (suite *HelperTests) TestTokenExpiration() {
 	err = CheckTokenExpiration(token)
 	assert.NoError(suite.T(), err)
 
-	w.Close() //nolint:errcheck
+	_ = w.Close()
 	out, _ := io.ReadAll(r)
 	os.Stderr = storeStderr
 
@@ -377,7 +377,7 @@ func (suite *HelperTests) TestTokenExpiration() {
 	err = CheckTokenExpiration(token)
 	assert.NoError(suite.T(), err)
 
-	w.Close() //nolint:errcheck
+	_ = w.Close()
 	out, _ = io.ReadAll(r)
 	os.Stderr = storeStderr
 

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/johannesboyne/gofakes3"
 	"github.com/johannesboyne/gofakes3/backend/s3mem"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"log"
 )
 
 type TestSuite struct {
@@ -67,7 +67,7 @@ func (suite *TestSuite) TestFunctionality() {
 	}
 	_, err := s3Client.CreateBucket(cparams)
 	if err != nil {
-		log.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 
 		return
 	}
@@ -109,7 +109,7 @@ func (suite *TestSuite) TestFunctionality() {
 	dir := "dummy"
 	err = os.Mkdir(dir, 0755)
 	if err != nil {
-		log.Error(err)
+		fmt.Fprintln(os.Stderr, err)
 	}
 	defer os.RemoveAll(dir) //nolint:errcheck
 

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -125,7 +125,7 @@ func (suite *TestSuite) TestFunctionality() {
 	err = upload.Upload(os.Args, configPath.Name())
 	assert.NoError(suite.T(), err)
 
-	uploadW.Close() //nolint:errcheck
+	_ = uploadW.Close()
 	os.Stdout = rescueStdout
 	uploadOutput, _ := io.ReadAll(uploadR)
 
@@ -146,13 +146,13 @@ func (suite *TestSuite) TestFunctionality() {
 	err = List(os.Args, configPath.Name())
 	assert.NoError(suite.T(), err)
 
-	w.Close() //nolint:errcheck
+	_ = w.Close()
 	os.Stdout = rescueStdout
 	listOutput, _ := io.ReadAll(r)
 	msg1 := fmt.Sprintf("%v", filepath.Base(testfile.Name()))
 	assert.Contains(suite.T(), string(listOutput), msg1)
 
-	errW.Close() //nolint:errcheck
+	_ = errW.Close()
 	os.Stderr = rescueStderr
 	listError, _ := io.ReadAll(errR)
 

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -91,7 +91,7 @@ func (suite *TestSuite) TestFunctionality() {
 	// Create config file
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd.conf")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 	defer os.Remove(configPath.Name()) //nolint:errcheck
@@ -115,7 +115,7 @@ func (suite *TestSuite) TestFunctionality() {
 	// Create test file to upload
 	testfile, err := os.CreateTemp(dir, "dummy")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 	defer os.Remove(testfile.Name()) //nolint:errcheck

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/johannesboyne/gofakes3/backend/s3mem"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"log"
 )
 
 type TestSuite struct {
@@ -92,14 +91,15 @@ func (suite *TestSuite) TestFunctionality() {
 	// Create config file
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd.conf")
 	if err != nil {
-		log.Panic(err)
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	// Write config file
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		log.Printf("failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
 	}
 
 	// Create dir for storing file
@@ -115,7 +115,8 @@ func (suite *TestSuite) TestFunctionality() {
 	// Create test file to upload
 	testfile, err := os.CreateTemp(dir, "dummy")
 	if err != nil {
-		log.Panic(err)
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 	defer os.Remove(testfile.Name()) //nolint:errcheck
 

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -65,9 +65,7 @@ func (suite *TestSuite) TestFunctionality() {
 	}
 	_, err := s3Client.CreateBucket(cparams)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-
-		return
+		suite.FailNow("failed to create s3 bucket", err)
 	}
 
 	// Create conf file for sda-cli
@@ -91,15 +89,14 @@ func (suite *TestSuite) TestFunctionality() {
 	// Create config file
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd.conf")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to create s3cmd.conf test file", err)
 	}
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	// Write config file
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
+		suite.FailNow("failed to write to s3cmd.conf test file", err)
 	}
 
 	// Create dir for storing file
@@ -108,15 +105,14 @@ func (suite *TestSuite) TestFunctionality() {
 	dir := "dummy"
 	err = os.Mkdir(dir, 0755)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		suite.FailNow("failed to create test directory", err)
 	}
 	defer os.RemoveAll(dir) //nolint:errcheck
 
 	// Create test file to upload
 	testfile, err := os.CreateTemp(dir, "dummy")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to create test file", err)
 	}
 	defer os.Remove(testfile.Name()) //nolint:errcheck
 

--- a/main.go
+++ b/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/NBISweden/sda-cli/login"
 	"github.com/NBISweden/sda-cli/upload"
 	"github.com/NBISweden/sda-cli/version"
-	log "github.com/sirupsen/logrus"
 )
 
 var Version = "0-development"
@@ -68,7 +67,7 @@ var Commands = map[string]commandInfo{
 
 // Main does argument parsing, then delegates to one of the sub modules
 func main() {
-	log.SetLevel(log.WarnLevel)
+
 	command, args, configPath := ParseArgs()
 
 	var err error

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -17,7 +17,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/neicnordic/crypt4gh/keys"
-	log "github.com/sirupsen/logrus"
 	"github.com/vbauerster/mpb/v8"
 	"github.com/vbauerster/mpb/v8/decor"
 )
@@ -117,7 +116,6 @@ func uploadFiles(files, outFiles []string, targetDir string, config *helpers.Con
 			}
 			if string(magicWord) != "crypt4gh" {
 				fmt.Fprintf(os.Stderr, "input file %s is not encrypted\n", filename)
-				log.Infof("input file %s is not encrypted\n", filepath.Clean(filename))
 				if !*forceUnencrypted {
 					fmt.Println("Quitting...")
 
@@ -252,7 +250,7 @@ func uploadFiles(files, outFiles []string, targetDir string, config *helpers.Con
 		if err != nil {
 			return err
 		}
-		log.Infof("file uploaded to %s\n", string(aws.StringValue(&result.Location)))
+		fmt.Printf("file uploaded to %s\n", aws.StringValue(&result.Location))
 
 		if *pubKeyPath != "" { //nolint: nestif
 			checksumFileUnencMd5, err := os.OpenFile("checksum_unencrypted.md5", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/neicnordic/crypt4gh/keys"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"log"
 )
 
 type TestSuite struct {
@@ -58,14 +57,15 @@ func (suite *TestSuite) TestSampleNoFiles() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd.conf")
 	if err != nil {
-		log.Fatal(err)
+		fmt.Fprint(os.Stderr, err)
+		os.Exit(1)
 	}
 
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		log.Printf("failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
 	}
 
 	// Test Upload function
@@ -105,13 +105,15 @@ func (suite *TestSuite) TestcreateFilePaths() {
 	// Create temp dir with file
 	dir, err := os.MkdirTemp(os.TempDir(), "test")
 	if err != nil {
-		log.Panic(err)
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 	defer os.RemoveAll(dir) //nolint:errcheck
 
 	testfile, err := os.CreateTemp(dir, "testfile")
 	if err != nil {
-		log.Panic(err)
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 	defer os.Remove(testfile.Name()) //nolint:errcheck
 
@@ -162,7 +164,8 @@ func (suite *TestSuite) TestFunctionality() {
 	}
 	_, err := s3Client.CreateBucket(cparams)
 	if err != nil {
-		log.Panic(err.Error())
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 
 	// Create conf file for sda-cli
@@ -185,29 +188,32 @@ func (suite *TestSuite) TestFunctionality() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd.conf")
 	if err != nil {
-		log.Panic(err)
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		log.Printf("failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
 	}
 
 	// Create temp dir with file
 	dir, err := os.MkdirTemp(os.TempDir(), "test")
 	if err != nil {
-		log.Panic(err)
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 	defer os.RemoveAll(dir) //nolint:errcheck
 
 	testfile, err := os.CreateTemp(dir, "testfile")
 	if err != nil {
-		log.Panic(err)
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 	err = os.WriteFile(testfile.Name(), []byte("content"), 0600)
 	if err != nil {
-		log.Printf("failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
 	}
 	defer os.Remove(testfile.Name()) //nolint:errcheck
 
@@ -244,7 +250,8 @@ func (suite *TestSuite) TestFunctionality() {
 		Bucket: aws.String("dummy"),
 	})
 	if err != nil {
-		log.Panic(err.Error())
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 	assert.Equal(suite.T(), aws.StringValue(result.Contents[0].Key), fmt.Sprintf("%s/%s", filepath.Base(dir), filepath.Base(testfile.Name())))
 
@@ -270,7 +277,8 @@ func (suite *TestSuite) TestFunctionality() {
 		Bucket: aws.String("dummy"),
 	})
 	if err != nil {
-		log.Panic(err.Error())
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 	assert.Equal(suite.T(), aws.StringValue(result.Contents[0].Key), fmt.Sprintf("%s/%s", filepath.ToSlash(targetPath), filepath.Base(testfile.Name())))
 
@@ -280,17 +288,23 @@ func (suite *TestSuite) TestFunctionality() {
 	// Generate a crypt4gh pub key
 	pubKeyData, _, err := keys.GenerateKeyPair()
 	if err != nil {
-		log.Panic("Couldn't generate key pair", err)
+		panicMsg := fmt.Sprint("Couldn't generate key pair", err)
+		fmt.Fprint(os.Stderr, panicMsg)
+		panic(panicMsg)
 	}
 
 	// Write the keys to temporary files
 	publicKey, err := os.CreateTemp(dir, "pubkey-")
 	if err != nil {
-		log.Panic("Cannot create temporary public key file", err)
+		panicMsg := fmt.Sprint("Cannot create temporary public key file", err)
+		fmt.Fprint(os.Stderr, panicMsg)
+		panic(panicMsg)
 	}
 
 	if err = keys.WriteCrypt4GHX25519PublicKey(publicKey, pubKeyData); err != nil {
-		log.Panicf("failed to write temporary public key file, %v", err)
+		panicMsg := fmt.Sprintf("failed to write temporary public key file, %v", err)
+		fmt.Fprint(os.Stderr, panicMsg)
+		panic(panicMsg)
 	}
 
 	rescuedStdout = os.Stdout
@@ -313,7 +327,8 @@ func (suite *TestSuite) TestFunctionality() {
 		Bucket: aws.String("dummy"),
 	})
 	if err != nil {
-		log.Panic(err.Error())
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 	assert.Equal(suite.T(), aws.StringValue(result.Contents[1].Key), "someDir/"+filepath.Base(testfile.Name())+".c4gh")
 
@@ -349,11 +364,12 @@ func (suite *TestSuite) TestFunctionality() {
 	// Check that trying to encrypt already encrypted files returns error and aborts
 	encFile, err := os.CreateTemp(dir, "encFile")
 	if err != nil {
-		log.Panic(err)
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 	err = os.WriteFile(encFile.Name(), []byte("crypt4gh"), 0600)
 	if err != nil {
-		log.Printf("failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
 	}
 	defer os.Remove(testfile.Name()) //nolint:errcheck
 	newArgs = []string{"upload", "--encrypt-with-key", publicKey.Name(), encFile.Name()}
@@ -409,16 +425,20 @@ func (suite *TestSuite) TestFunctionality() {
 
 	// Remove hash files created by Encrypt
 	if err := os.Remove("checksum_encrypted.md5"); err != nil {
-		log.Panic(err)
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 	if err := os.Remove("checksum_unencrypted.md5"); err != nil {
-		log.Panic(err)
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 	if err := os.Remove("checksum_encrypted.sha256"); err != nil {
-		log.Panic(err)
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 	if err := os.Remove("checksum_unencrypted.sha256"); err != nil {
-		log.Panic(err)
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 
 }
@@ -448,7 +468,7 @@ func (suite *TestSuite) TestRecursiveToDifferentTarget() {
 	}
 	_, err := s3Client.CreateBucket(cparams)
 	if err != nil {
-		log.Print(err.Error())
+		fmt.Fprint(os.Stderr, err.Error())
 	}
 
 	// Create conf file for sda-cli
@@ -471,29 +491,29 @@ func (suite *TestSuite) TestRecursiveToDifferentTarget() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd.conf")
 	if err != nil {
-		log.Print(err.Error())
+		fmt.Fprint(os.Stderr, err.Error())
 	}
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		log.Printf("failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
 	}
 
 	// Create temp dir with file
 	dir, err := os.MkdirTemp(os.TempDir(), "test")
 	if err != nil {
-		log.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 	}
 	defer os.RemoveAll(dir) //nolint:errcheck
 
 	testfile, err := os.CreateTemp(dir, "testfile")
 	if err != nil {
-		log.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 	}
 	err = os.WriteFile(testfile.Name(), []byte("content"), 0600)
 	if err != nil {
-		log.Printf("failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
 	}
 	defer os.Remove(testfile.Name()) //nolint:errcheck
 
@@ -519,11 +539,10 @@ func (suite *TestSuite) TestRecursiveToDifferentTarget() {
 		Bucket: aws.String("dummy"),
 	})
 	if err != nil {
-		log.Print(err.Error())
+		fmt.Fprint(os.Stderr, err.Error())
 	}
 	assert.Equal(suite.T(), filepath.ToSlash(filepath.Join(targetPath, filepath.Base(dir), filepath.Base(testfile.Name()))), aws.StringValue(result.Contents[0].Key))
 
-	log.SetOutput(os.Stdout)
 }
 
 func (suite *TestSuite) TestUploadInvalidCharacters() {
@@ -553,19 +572,22 @@ func (suite *TestSuite) TestUploadInvalidCharacters() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd.conf")
 	if err != nil {
-		log.Panic(err)
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		log.Panic(err)
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 
 	// Create temp dir with file
 	dir, err := os.MkdirTemp(os.TempDir(), "test")
 	if err != nil {
-		log.Panic(err)
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 	defer os.RemoveAll(dir) //nolint:errcheck
 
@@ -574,11 +596,13 @@ func (suite *TestSuite) TestUploadInvalidCharacters() {
 	var testfile *os.File
 	testfile, err = os.Create(filepath.Join(dir, testfilepath))
 	if err != nil {
-		log.Panic(err)
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 	err = os.WriteFile(testfile.Name(), []byte("content"), 0600)
 	if err != nil {
-		log.Panic(err)
+		fmt.Fprint(os.Stderr, err)
+		panic(err)
 	}
 	defer os.Remove(testfile.Name()) //nolint:errcheck
 
@@ -609,11 +633,13 @@ func (suite *TestSuite) TestUploadInvalidCharacters() {
 		var testfile *os.File
 		testfile, err := os.Create(filepath.Join(dir, testfilepath))
 		if err != nil {
-			log.Panic(err)
+			fmt.Fprint(os.Stderr, err)
+			panic(err)
 		}
 		err = os.WriteFile(testfile.Name(), []byte("content"), 0600)
 		if err != nil {
-			log.Panic(err)
+			fmt.Fprint(os.Stderr, err)
+			panic(err)
 		}
 		defer os.Remove(testfile.Name()) //nolint:errcheck
 

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/johannesboyne/gofakes3"
 	"github.com/johannesboyne/gofakes3/backend/s3mem"
 	"github.com/neicnordic/crypt4gh/keys"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"log"
 )
 
 type TestSuite struct {

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -57,7 +57,7 @@ func (suite *TestSuite) TestSampleNoFiles() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd.conf")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -65,7 +65,7 @@ func (suite *TestSuite) TestSampleNoFiles() {
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
 	}
 
 	// Test Upload function
@@ -105,14 +105,14 @@ func (suite *TestSuite) TestcreateFilePaths() {
 	// Create temp dir with file
 	dir, err := os.MkdirTemp(os.TempDir(), "test")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 	defer os.RemoveAll(dir) //nolint:errcheck
 
 	testfile, err := os.CreateTemp(dir, "testfile")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 	defer os.Remove(testfile.Name()) //nolint:errcheck
@@ -164,7 +164,7 @@ func (suite *TestSuite) TestFunctionality() {
 	}
 	_, err := s3Client.CreateBucket(cparams)
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 
@@ -188,32 +188,32 @@ func (suite *TestSuite) TestFunctionality() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd.conf")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
 	}
 
 	// Create temp dir with file
 	dir, err := os.MkdirTemp(os.TempDir(), "test")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 	defer os.RemoveAll(dir) //nolint:errcheck
 
 	testfile, err := os.CreateTemp(dir, "testfile")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 	err = os.WriteFile(testfile.Name(), []byte("content"), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
 	}
 	defer os.Remove(testfile.Name()) //nolint:errcheck
 
@@ -250,7 +250,7 @@ func (suite *TestSuite) TestFunctionality() {
 		Bucket: aws.String("dummy"),
 	})
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 	assert.Equal(suite.T(), aws.StringValue(result.Contents[0].Key), fmt.Sprintf("%s/%s", filepath.Base(dir), filepath.Base(testfile.Name())))
@@ -277,7 +277,7 @@ func (suite *TestSuite) TestFunctionality() {
 		Bucket: aws.String("dummy"),
 	})
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 	assert.Equal(suite.T(), aws.StringValue(result.Contents[0].Key), fmt.Sprintf("%s/%s", filepath.ToSlash(targetPath), filepath.Base(testfile.Name())))
@@ -289,7 +289,7 @@ func (suite *TestSuite) TestFunctionality() {
 	pubKeyData, _, err := keys.GenerateKeyPair()
 	if err != nil {
 		panicMsg := fmt.Sprint("Couldn't generate key pair", err)
-		fmt.Fprint(os.Stderr, panicMsg)
+		fmt.Fprintln(os.Stderr, panicMsg)
 		panic(panicMsg)
 	}
 
@@ -297,13 +297,13 @@ func (suite *TestSuite) TestFunctionality() {
 	publicKey, err := os.CreateTemp(dir, "pubkey-")
 	if err != nil {
 		panicMsg := fmt.Sprint("Cannot create temporary public key file", err)
-		fmt.Fprint(os.Stderr, panicMsg)
+		fmt.Fprintln(os.Stderr, panicMsg)
 		panic(panicMsg)
 	}
 
 	if err = keys.WriteCrypt4GHX25519PublicKey(publicKey, pubKeyData); err != nil {
 		panicMsg := fmt.Sprintf("failed to write temporary public key file, %v", err)
-		fmt.Fprint(os.Stderr, panicMsg)
+		fmt.Fprintln(os.Stderr, panicMsg)
 		panic(panicMsg)
 	}
 
@@ -327,7 +327,7 @@ func (suite *TestSuite) TestFunctionality() {
 		Bucket: aws.String("dummy"),
 	})
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 	assert.Equal(suite.T(), aws.StringValue(result.Contents[1].Key), "someDir/"+filepath.Base(testfile.Name())+".c4gh")
@@ -364,12 +364,12 @@ func (suite *TestSuite) TestFunctionality() {
 	// Check that trying to encrypt already encrypted files returns error and aborts
 	encFile, err := os.CreateTemp(dir, "encFile")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 	err = os.WriteFile(encFile.Name(), []byte("crypt4gh"), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
 	}
 	defer os.Remove(testfile.Name()) //nolint:errcheck
 	newArgs = []string{"upload", "--encrypt-with-key", publicKey.Name(), encFile.Name()}
@@ -425,19 +425,19 @@ func (suite *TestSuite) TestFunctionality() {
 
 	// Remove hash files created by Encrypt
 	if err := os.Remove("checksum_encrypted.md5"); err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 	if err := os.Remove("checksum_unencrypted.md5"); err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 	if err := os.Remove("checksum_encrypted.sha256"); err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 	if err := os.Remove("checksum_unencrypted.sha256"); err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 
@@ -468,7 +468,7 @@ func (suite *TestSuite) TestRecursiveToDifferentTarget() {
 	}
 	_, err := s3Client.CreateBucket(cparams)
 	if err != nil {
-		fmt.Fprint(os.Stderr, err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 	}
 
 	// Create conf file for sda-cli
@@ -491,13 +491,13 @@ func (suite *TestSuite) TestRecursiveToDifferentTarget() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd.conf")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 	}
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
 	}
 
 	// Create temp dir with file
@@ -513,7 +513,7 @@ func (suite *TestSuite) TestRecursiveToDifferentTarget() {
 	}
 	err = os.WriteFile(testfile.Name(), []byte("content"), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v", err)
+		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
 	}
 	defer os.Remove(testfile.Name()) //nolint:errcheck
 
@@ -539,7 +539,7 @@ func (suite *TestSuite) TestRecursiveToDifferentTarget() {
 		Bucket: aws.String("dummy"),
 	})
 	if err != nil {
-		fmt.Fprint(os.Stderr, err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 	}
 	assert.Equal(suite.T(), filepath.ToSlash(filepath.Join(targetPath, filepath.Base(dir), filepath.Base(testfile.Name()))), aws.StringValue(result.Contents[0].Key))
 
@@ -572,21 +572,21 @@ func (suite *TestSuite) TestUploadInvalidCharacters() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd.conf")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 
 	// Create temp dir with file
 	dir, err := os.MkdirTemp(os.TempDir(), "test")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 	defer os.RemoveAll(dir) //nolint:errcheck
@@ -596,12 +596,12 @@ func (suite *TestSuite) TestUploadInvalidCharacters() {
 	var testfile *os.File
 	testfile, err = os.Create(filepath.Join(dir, testfilepath))
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 	err = os.WriteFile(testfile.Name(), []byte("content"), 0600)
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		panic(err)
 	}
 	defer os.Remove(testfile.Name()) //nolint:errcheck
@@ -633,12 +633,12 @@ func (suite *TestSuite) TestUploadInvalidCharacters() {
 		var testfile *os.File
 		testfile, err := os.Create(filepath.Join(dir, testfilepath))
 		if err != nil {
-			fmt.Fprint(os.Stderr, err)
+			fmt.Fprintln(os.Stderr, err)
 			panic(err)
 		}
 		err = os.WriteFile(testfile.Name(), []byte("content"), 0600)
 		if err != nil {
-			fmt.Fprint(os.Stderr, err)
+			fmt.Fprintln(os.Stderr, err)
 			panic(err)
 		}
 		defer os.Remove(testfile.Name()) //nolint:errcheck

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -57,15 +57,14 @@ func (suite *TestSuite) TestSampleNoFiles() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd.conf")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		suite.FailNow("failed to create s3cmd.conf", err)
 	}
 
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
+		suite.FailNow("failed to write to s3cmd.conf", err)
 	}
 
 	// Test Upload function
@@ -105,15 +104,13 @@ func (suite *TestSuite) TestcreateFilePaths() {
 	// Create temp dir with file
 	dir, err := os.MkdirTemp(os.TempDir(), "test")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to create temp test directory", err)
 	}
 	defer os.RemoveAll(dir) //nolint:errcheck
 
 	testfile, err := os.CreateTemp(dir, "testfile")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to create test file", err)
 	}
 	defer os.Remove(testfile.Name()) //nolint:errcheck
 
@@ -164,8 +161,7 @@ func (suite *TestSuite) TestFunctionality() {
 	}
 	_, err := s3Client.CreateBucket(cparams)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to create s3 bucket", err)
 	}
 
 	// Create conf file for sda-cli
@@ -188,32 +184,29 @@ func (suite *TestSuite) TestFunctionality() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd.conf")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to create s3cmd.conf", err)
 	}
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
+		suite.FailNow("failed to write to s3cmd.conf", err)
 	}
 
 	// Create temp dir with file
 	dir, err := os.MkdirTemp(os.TempDir(), "test")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to create temp test directory", err)
 	}
 	defer os.RemoveAll(dir) //nolint:errcheck
 
 	testfile, err := os.CreateTemp(dir, "testfile")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to create test file", err)
 	}
 	err = os.WriteFile(testfile.Name(), []byte("content"), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
+		suite.FailNow("failed to write to test file", err)
 	}
 	defer os.Remove(testfile.Name()) //nolint:errcheck
 
@@ -250,8 +243,7 @@ func (suite *TestSuite) TestFunctionality() {
 		Bucket: aws.String("dummy"),
 	})
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to list objects from s3", err)
 	}
 	assert.Equal(suite.T(), aws.StringValue(result.Contents[0].Key), fmt.Sprintf("%s/%s", filepath.Base(dir), filepath.Base(testfile.Name())))
 
@@ -277,8 +269,7 @@ func (suite *TestSuite) TestFunctionality() {
 		Bucket: aws.String("dummy"),
 	})
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to list objects from s3", err)
 	}
 	assert.Equal(suite.T(), aws.StringValue(result.Contents[0].Key), fmt.Sprintf("%s/%s", filepath.ToSlash(targetPath), filepath.Base(testfile.Name())))
 
@@ -288,23 +279,17 @@ func (suite *TestSuite) TestFunctionality() {
 	// Generate a crypt4gh pub key
 	pubKeyData, _, err := keys.GenerateKeyPair()
 	if err != nil {
-		panicMsg := fmt.Sprint("Couldn't generate key pair", err)
-		fmt.Fprintln(os.Stderr, panicMsg)
-		panic(panicMsg)
+		suite.FailNow("Couldn't generate key pair", err)
 	}
 
 	// Write the keys to temporary files
 	publicKey, err := os.CreateTemp(dir, "pubkey-")
 	if err != nil {
-		panicMsg := fmt.Sprint("Cannot create temporary public key file", err)
-		fmt.Fprintln(os.Stderr, panicMsg)
-		panic(panicMsg)
+		suite.FailNow("Cannot create temporary public key file", err)
 	}
 
 	if err = keys.WriteCrypt4GHX25519PublicKey(publicKey, pubKeyData); err != nil {
-		panicMsg := fmt.Sprintf("failed to write temporary public key file, %v", err)
-		fmt.Fprintln(os.Stderr, panicMsg)
-		panic(panicMsg)
+		suite.FailNow("failed to write temporary public key file, %v", err)
 	}
 
 	rescuedStdout = os.Stdout
@@ -327,8 +312,7 @@ func (suite *TestSuite) TestFunctionality() {
 		Bucket: aws.String("dummy"),
 	})
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to list objects from s3", err)
 	}
 	assert.Equal(suite.T(), aws.StringValue(result.Contents[1].Key), "someDir/"+filepath.Base(testfile.Name())+".c4gh")
 
@@ -364,12 +348,11 @@ func (suite *TestSuite) TestFunctionality() {
 	// Check that trying to encrypt already encrypted files returns error and aborts
 	encFile, err := os.CreateTemp(dir, "encFile")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to create test file", err)
 	}
 	err = os.WriteFile(encFile.Name(), []byte("crypt4gh"), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
+		suite.FailNow("failed to write to test file", err)
 	}
 	defer os.Remove(testfile.Name()) //nolint:errcheck
 	newArgs = []string{"upload", "--encrypt-with-key", publicKey.Name(), encFile.Name()}
@@ -399,7 +382,7 @@ func (suite *TestSuite) TestFunctionality() {
 
 	err = os.WriteFile(configPath.Name(), []byte(confFileNoToken), 0600)
 	if err != nil {
-		suite.FailNow("failed to write temp config file, %v", err)
+		suite.FailNow("failed to write temp config file", err)
 	}
 
 	// Check that an access token is supplied
@@ -425,20 +408,16 @@ func (suite *TestSuite) TestFunctionality() {
 
 	// Remove hash files created by Encrypt
 	if err := os.Remove("checksum_encrypted.md5"); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to delete checksum_encrypted.md5", err)
 	}
 	if err := os.Remove("checksum_unencrypted.md5"); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to delete checksum_unencrypted.md5", err)
 	}
 	if err := os.Remove("checksum_encrypted.sha256"); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to delete checksum_encrypted.sha256", err)
 	}
 	if err := os.Remove("checksum_unencrypted.sha256"); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to delete checksum_unencrypted.sha256", err)
 	}
 
 }
@@ -468,7 +447,7 @@ func (suite *TestSuite) TestRecursiveToDifferentTarget() {
 	}
 	_, err := s3Client.CreateBucket(cparams)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
+		suite.FailNow("failed to create s3 bucket", err)
 	}
 
 	// Create conf file for sda-cli
@@ -491,29 +470,29 @@ func (suite *TestSuite) TestRecursiveToDifferentTarget() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd.conf")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
+		suite.FailNow("failed to create temp s3cmd.conf file", err)
 	}
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
+		suite.FailNow("failed to write to temp s3cmd.conf file", err)
 	}
 
 	// Create temp dir with file
 	dir, err := os.MkdirTemp(os.TempDir(), "test")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		suite.FailNow("failed to create test directory", err)
 	}
 	defer os.RemoveAll(dir) //nolint:errcheck
 
 	testfile, err := os.CreateTemp(dir, "testfile")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		suite.FailNow("failed to create test file", err)
 	}
 	err = os.WriteFile(testfile.Name(), []byte("content"), 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write temp config file, %v\n", err)
+		suite.FailNow("failed to write to test file", err)
 	}
 	defer os.Remove(testfile.Name()) //nolint:errcheck
 
@@ -539,7 +518,7 @@ func (suite *TestSuite) TestRecursiveToDifferentTarget() {
 		Bucket: aws.String("dummy"),
 	})
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
+		suite.FailNow("failed to list obects from s3", err)
 	}
 	assert.Equal(suite.T(), filepath.ToSlash(filepath.Join(targetPath, filepath.Base(dir), filepath.Base(testfile.Name()))), aws.StringValue(result.Contents[0].Key))
 
@@ -572,22 +551,19 @@ func (suite *TestSuite) TestUploadInvalidCharacters() {
 
 	configPath, err := os.CreateTemp(os.TempDir(), "s3cmd.conf")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to create temp s3cmd.conf", err)
 	}
 	defer os.Remove(configPath.Name()) //nolint:errcheck
 
 	err = os.WriteFile(configPath.Name(), []byte(confFile), 0600)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to write to temp s3cmd.conf", err)
 	}
 
 	// Create temp dir with file
 	dir, err := os.MkdirTemp(os.TempDir(), "test")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to create test directory", err)
 	}
 	defer os.RemoveAll(dir) //nolint:errcheck
 
@@ -596,13 +572,11 @@ func (suite *TestSuite) TestUploadInvalidCharacters() {
 	var testfile *os.File
 	testfile, err = os.Create(filepath.Join(dir, testfilepath))
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to create test file", err)
 	}
 	err = os.WriteFile(testfile.Name(), []byte("content"), 0600)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		panic(err)
+		suite.FailNow("failed to write to test file", err)
 	}
 	defer os.Remove(testfile.Name()) //nolint:errcheck
 
@@ -633,13 +607,11 @@ func (suite *TestSuite) TestUploadInvalidCharacters() {
 		var testfile *os.File
 		testfile, err := os.Create(filepath.Join(dir, testfilepath))
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			panic(err)
+			suite.FailNow("failed to create test file", err)
 		}
 		err = os.WriteFile(testfile.Name(), []byte("content"), 0600)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			panic(err)
+			suite.FailNow("failed to write to test file", err)
 		}
 		defer os.Remove(testfile.Name()) //nolint:errcheck
 

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -222,11 +222,11 @@ func (suite *TestSuite) TestFunctionality() {
 	os.Args = []string{"upload", "--force-unencrypted", "-r", dir}
 	assert.NoError(suite.T(), Upload(os.Args, configPath.Name()))
 
-	stdoutWriter.Close() //nolint:errcheck
+	_ = stdoutWriter.Close()
 	os.Stdout = rescuedStdout
 	uploadStdout, _ := io.ReadAll(stdoutReader)
 
-	stderrWriter.Close() //nolint:errcheck
+	_ = stderrWriter.Close()
 	os.Stderr = rescuedStderr
 	uploadStderr, _ := io.ReadAll(stderrReader)
 
@@ -256,7 +256,7 @@ func (suite *TestSuite) TestFunctionality() {
 	os.Args = []string{"upload", "--force-unencrypted", testfile.Name(), "-targetDir", targetPath}
 	assert.NoError(suite.T(), Upload(os.Args, configPath.Name()))
 
-	stdoutWriter.Close() //nolint:errcheck
+	_ = stdoutWriter.Close()
 	os.Stdout = rescuedStdout
 	uploadStdout, _ = io.ReadAll(stdoutReader)
 
@@ -299,7 +299,7 @@ func (suite *TestSuite) TestFunctionality() {
 	newArgs := []string{"upload", "--force-unencrypted", "--encrypt-with-key", publicKey.Name(), testfile.Name(), "-targetDir", "someDir"}
 	assert.NoError(suite.T(), Upload(newArgs, configPath.Name()))
 
-	stdoutWriter.Close() //nolint:errcheck
+	_ = stdoutWriter.Close()
 	os.Stdout = rescuedStdout
 	uploadStdout, _ = io.ReadAll(stdoutReader)
 
@@ -331,11 +331,11 @@ func (suite *TestSuite) TestFunctionality() {
 	os.Args = []string{"upload", "--force-unencrypted", "-r", dir}
 	_ = Upload(os.Args, configPath.Name())
 
-	stdoutWriter.Close() //nolint:errcheck
+	_ = stdoutWriter.Close()
 	os.Stdout = rescuedStdout
 	uploadStdout, _ = io.ReadAll(stdoutReader)
 
-	stderrWriter.Close() //nolint:errcheck
+	_ = stderrWriter.Close()
 	os.Stderr = rescuedStderr
 	uploadStderr, _ = io.ReadAll(stderrReader)
 
@@ -505,7 +505,7 @@ func (suite *TestSuite) TestRecursiveToDifferentTarget() {
 	os.Args = []string{"upload", "--force-unencrypted", "-r", dir, "-targetDir", targetPath}
 	assert.NoError(suite.T(), Upload(os.Args, configPath.Name()))
 
-	stdoutWriter.Close() //nolint:errcheck
+	_ = stdoutWriter.Close()
 	os.Stdout = rescuedStdout
 	uploadStdout, _ := io.ReadAll(stdoutReader)
 

--- a/version/version.go
+++ b/version/version.go
@@ -44,7 +44,7 @@ func Version(ver string) error {
 
 	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initiate request")
+		fmt.Fprintln(os.Stderr, "failed to initiate request")
 		fmt.Println("sda-cli version: ", ver)
 
 		return nil

--- a/version/version.go
+++ b/version/version.go
@@ -55,7 +55,7 @@ func Version(ver string) error {
 	client := &http.Client{Timeout: timeout}
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to fetch releases, reason: %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "failed to fetch releases, reason: %v\n", err.Error())
 		fmt.Println("sda-cli version: ", ver)
 
 		return nil


### PR DESCRIPTION
**Related issue(s) and PR(s)**  

This PR closes #455 


**Description**

This PR aims to remove the use of the github.com/sirupsen/logrus package and unify the logging to stdout through `fmt.Println` and `fmt.PrintF`, and to stderr through `fmt.Fprintf` and `fmt.Fprintln`.


**How to test**
Run unit tests to ensure tested outputs remains as expected 

