### PR TITLE
hotfix for continue flag parsing

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -134,6 +134,8 @@ func getPositional(args []string) ([]string, []string) {
 		"--from-file",
 		"--clean",
 		"-clean",
+		"--continue",
+		"-continue",
 	}
 	i := 1
 	var positional []string


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #557.


**Description**
This is a hotfix for the parsing of the `continue` flag in the arguments. We currently hardcode a list of the positional arguments that don't come with an expected argument after them.  `continue` was missing from that list.

**How to test**

try some cases of using that flag in random positions.
```
../sda-cli -config s3cmd-bp-staging.conf upload -continue -encrypt-with-key mykey.pub.pem  -r test_dir1
../sda-cli -config s3cmd-bp-staging.conf upload -encrypt-with-key mykey.pub.pem  -r test_dir1 -continue  -targetDir test_dir1_try5

```

