### PR TITLE
Group dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,10 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
-    reviewers:
-      - "nbisweden/sda-developers"
+    groups:
+      all-modules:
+        patterns:
+          - "*"
   - package-ecosystem: docker
     directory: ./
     schedule:
@@ -16,5 +18,7 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
-    reviewers:
-      - "nbisweden/sda-developers"
+    groups:
+      all-modules:
+        patterns:
+          - "*"


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #576 .


**Description**
This PR updates the dependabot config so that the PRs can be grouped into a single PR instead of separate PRs for every library that gets updated.
