### PR TITLE
[testing] Update reencrypt configuration to new expected format

### DIFF
--- a/testing/docker-compose.yml
+++ b/testing/docker-compose.yml
@@ -261,13 +261,12 @@ services:
     container_name: reencrypt
     environment:
       - LOG_LEVEL=debug
-      - C4GH_PASSPHRASE=oaagCP1YgAZeEyl2eJAkHv9lkcWXWFgm
-      - C4GH_FILEPATH=/dev_utils/c4gh.sec.pem
     ports:
       - "50051:50051"
     restart: always
     volumes:
-      - ./:/dev_utils/
+      - ./:/dev_utils
+      - ./reencrypt_config.yaml:/config.yaml
 volumes:
   data:
   dbdata:

--- a/testing/reencrypt_config.yaml
+++ b/testing/reencrypt_config.yaml
@@ -1,0 +1,4 @@
+c4gh:
+  privateKeys:
+    - filePath: "/dev_utils/c4gh.sec.pem"
+      passphrase: "oaagCP1YgAZeEyl2eJAkHv9lkcWXWFgm"


### PR DESCRIPTION
# Related issue(s) and PR(s)
This PR closes #593 


# Description
Update the reencrypt configuration, pass c4gh key in new format through config file instead of env vars

# How to test
Check that the [integration test](https://github.com/NBISweden/sda-cli/blob/main/.github/workflows/integration.yml) is succesful
