### PR TITLE
Use version 18.2 of ceph

### DIFF
--- a/testing/docker-compose.yml
+++ b/testing/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 3
-    image: ceph/daemon:v5.0.1-stable-5.0-octopus-centos-8-x86_64
+    image: quay.io/ceph/vstart-cluster:18.2.7
     ports:
       - "5100:5100"
       - "8100:8100"


### PR DESCRIPTION
Use newer version of ceph in the docker-compose file

**Related issue(s) and PR(s)**  
This PR closes [issue number].


**Description**


**How to test**
