### PR TITLE
Remove documentation about downloading with fileID

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,13 +378,6 @@ output folder, use the `-outdir` flag. Additionally, if `<filepath>` includes a
 nested folder structure, the original directory hierarchy will be preserved
 during the download process.
 
-#### Using file IDs
-
-Downloading specific files by their file IDs follows the same syntax as
-downloading files by file paths. The only difference is that you replace the
-file paths with their corresponding file IDs. Ensure that the file IDs do not
-contain slashes (`/`).
-
 ### Download files recursively
 
 To download the contents of a folder, including all subfolders, use the


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
It is related to [this issue](https://app.zenhub.com/workspaces/giant-sloth-6041ec3fd9297d0016321f73/issues/gh/nbisweden/bigpicture-deployment/510)


**Description**
Removing the information about downloading with fileID because it cannot happen since the user cannot know the file ID since it is our internal ID
