### PR TITLE
Update GoReleaser configuration to version 2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
 # The file contains the options for the release package
 # Make sure to check the documentation at https://goreleaser.com
+version: 2
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
The config file needs the version tag or the release action will fail.
