### PR TITLE
Fix display of upload file location

### DIFF
--- a/upload/upload.go
+++ b/upload/upload.go
@@ -238,7 +238,6 @@ func uploadFiles(files, outFiles []string, targetDir string, config *helpers.Con
 		if err != nil {
 			return err
 		}
-		fmt.Printf("file uploaded to %s\n", aws.ToString(&result.Location))
 
 		if encryptWithKey != "" { //nolint:nestif
 			checksumFileUnencMd5, err := os.OpenFile("checksum_unencrypted.md5", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
@@ -279,6 +278,7 @@ func uploadFiles(files, outFiles []string, targetDir string, config *helpers.Con
 		}
 
 		p.Shutdown()
+		fmt.Printf("file uploaded to %s\n", aws.ToString(&result.Location))
 	}
 
 	return nil


### PR DESCRIPTION
The call to shutdown the progress bar (p.Shutdown) clears the last line of output, causing the text "file uploaded to %s" to be removed and instead the finished progressbar is shown twice.

Moving the Printf to after p.Shutdown fixes this.

**Related issue(s) and PR(s)**  
This PR closes [issue number].


**Description**


**How to test**
