### PR TITLE
[upload,list] Migrate to feature/s3/transfermanager

### DIFF
--- a/.github/integration/tests/10_encrypt_decrypt.sh
+++ b/.github/integration/tests/10_encrypt_decrypt.sh
@@ -6,6 +6,9 @@ source "$test_dir/../scripts/checkers.sh"
 # Create random file
 dd if=/dev/urandom of=data_file count=10 bs=1M
 
+# Larger file to exercise multipart upload path (>50 MiB chunk threshold)
+dd if=/dev/urandom of=data_file_big count=60 bs=1M
+
 # Create key pair
 if ( yes "" | ./sda-cli createKey sda_key ) ; then
     echo "Created key pair for encryption"
@@ -18,6 +21,9 @@ fi
 ./sda-cli encrypt --key sda_key.pub.pem data_file
 
 check_encrypted_file data_file.c4gh
+
+./sda-cli encrypt --key sda_key.pub.pem data_file_big
+check_encrypted_file data_file_big.c4gh
 
 
 # Create folder and encrypt files in it

--- a/.github/integration/tests/20_upload.sh
+++ b/.github/integration/tests/20_upload.sh
@@ -19,6 +19,20 @@ cp data_files_enc/data_file.c4gh data_files_enc/dir1/dir2/data_file2.c4gh
 ./sda-cli --config testing/s3cmd.conf upload data_file.c4gh
 check_uploaded_file "test/$user/data_file.c4gh" data_file.c4gh
 
+# Exercise multipart code path (PartSizeBytes=50MiB, file>60MiB encrypted)
+./sda-cli --config testing/s3cmd.conf upload data_file_big.c4gh
+if ! s3cmd -c testing/directS3 ls "s3://test/$user/data_file_big.c4gh" | grep -q data_file_big.c4gh; then
+    echo "Multipart upload missing from s3 backend"
+    exit 1
+fi
+s3size=$(s3cmd -c testing/directS3 ls "s3://test/$user/data_file_big.c4gh" | awk '{print $3}')
+local_size=$(wc -c < data_file_big.c4gh | awk '{print $1}')
+if [ "$s3size" != "$local_size" ]; then
+    echo "Multipart upload size mismatch: s3=$s3size local=$local_size"
+    exit 1
+fi
+echo "Multipart upload verified ($s3size bytes)"
+
 # Upload the file twice check that this returns an error
 msg=$(./sda-cli --config testing/s3cmd.conf upload data_file.c4gh 2>&1 | tail -1 || true)
 if ! grep -q "Error:" <<< "$msg"

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
-	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.15
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.1
+	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.18
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/hashicorp/go-version v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.15 h1:fyvgWTszojq8hEnMi8PPBTvZdTt
 github.com/aws/aws-sdk-go-v2/credentials v1.19.15/go.mod h1:gJiYyMOjNg8OEdRWOf3CrFQxM2a98qmrtjx1zuiQfB8=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22 h1:IOGsJ1xVWhsi+ZO7/NW8OuZZBtMJLZbk4P5HDjJO0jQ=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22/go.mod h1:b+hYdbU+jGKfXE8kKM6g1+h+L/Go3vMvzlxBsiuGsxg=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.15 h1:dZtEWZXGstKR/3imex5lC6WmdlH+na12AoYqi+dzrtk=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.15/go.mod h1:H8jD3r6e2bNQvdOK47TiYkxZfegWbAbyCkqPaL5FYNw=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.18 h1:RtBqcC84feV8kTqFVq1uX9q+Sd9bL9jctEWjF02Tss0=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.18/go.mod h1:B5OSVaJ4Qqvpt6eZTxjFejGOuW8RpMV0IRm+4x+Ksls=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 h1:GmLa5Kw1ESqtFpXsx5MmC84QWa/ZrLZvlJGa2y+4kcQ=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22/go.mod h1:6sW9iWm9DK9YRpRGga/qzrzNLgKpT2cIxb7Vo2eNOp0=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 h1:dY4kWZiSaXIzxnKlj17nHnBcXXBfac6UlsAx2qL6XrU=
@@ -33,8 +33,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.22 h1:PUmZeJU6
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.22/go.mod h1:nO6egFBoAaoXze24a2C0NjQCvdpk8OueRoYimvEB9jo=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.22 h1:SE+aQ4DEqG53RRCAIHlCf//B2ycxGH7jFkpnAh/kKPM=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.22/go.mod h1:ES3ynECd7fYeJIL6+oax+uIEljmfps0S70BaQzbMd/o=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.99.1 h1:kU/eBN5+MWNo/LcbNa4hWDdN76hdcd7hocU5kvu7IsU=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.99.1/go.mod h1:Fw9aqhJicIVee1VytBBjH+l+5ov6/PhbtIK/u3rt/ls=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.100.0 h1:7G26Sae6PMKn4kMcU5JzNfrm1YrKwyOhowXPYR2WiWY=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.100.0/go.mod h1:Fw9aqhJicIVee1VytBBjH+l+5ov6/PhbtIK/u3rt/ls=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.10 h1:a1Fq/KXn75wSzoJaPQTgZO0wHGqE9mjFnylnqEPTchA=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.10/go.mod h1:p6+MXNxW7IA6dMgHfTAzljuwSKD0NCm/4lbS4t6+7vI=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.16 h1:x6bKbmDhsgSZwv6q19wY/u3rLk/3FGjJWyqKcIRufpE=

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/golang-jwt/jwt"
 	"github.com/johannesboyne/gofakes3"
@@ -86,11 +86,11 @@ func (s *ListTestSuite) SetupSuite() {
 	if err != nil {
 		s.FailNow("failed to create s3 bucket", err)
 	}
-	uploader := manager.NewUploader(s3Client)
+	uploader := transfermanager.New(s3Client)
 
 	fileToUpload := strings.NewReader("test content")
 	s.testFilePath = "dummy/testfile"
-	if _, err := uploader.Upload(context.Background(), &s3.PutObjectInput{
+	if _, err := uploader.UploadObject(context.Background(), &transfermanager.UploadObjectInput{
 		Body:            fileToUpload,
 		Bucket:          aws.String("dummy"),
 		Key:             aws.String(s.testFilePath),

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -276,10 +277,14 @@ func uploadFiles(files, outFiles []string, targetDir string, config *helpers.Con
 		}
 
 		p.Shutdown()
+		keySegments := strings.Split(path.Join(targetDir, outFiles[k]), "/")
+		for i := range keySegments {
+			keySegments[i] = url.PathEscape(keySegments[i])
+		}
 		fmt.Printf("file uploaded to %s/%s/%s\n",
 			strings.TrimRight(config.HostBase, "/"),
-			config.AccessKey,
-			path.Join(targetDir, outFiles[k]))
+			url.PathEscape(config.AccessKey),
+			strings.Join(keySegments, "/"))
 	}
 
 	return nil

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/neicnordic/crypt4gh/keys"
 	"github.com/spf13/cobra"
@@ -130,7 +130,9 @@ func uploadFiles(files, outFiles []string, targetDir string, config *helpers.Con
 	})
 
 	// Create an uploader with the session and default options
-	uploader := manager.NewUploader(s3Client)
+	uploader := transfermanager.New(s3Client, func(o *transfermanager.Options) {
+		o.PartSizeBytes = config.MultipartChunkSizeMb * 1024 * 1024
+	})
 	for k, filename := range files {
 		// create progress bar instance
 		p := mpb.New()
@@ -221,15 +223,11 @@ func uploadFiles(files, outFiles []string, targetDir string, config *helpers.Con
 		)
 
 		// Upload the file to S3.
-		result, err := uploader.Upload(ctx, &s3.PutObjectInput{
+		result, err := uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
 			Body:            bar.ProxyReader(fs.Reader),
 			Bucket:          aws.String(config.AccessKey),
 			Key:             aws.String(path.Join(targetDir, outFiles[k])),
 			ContentEncoding: aws.String(config.Encoding),
-		}, func(u *manager.Uploader) {
-			u.PartSize = config.MultipartChunkSizeMb * 1024 * 1024
-			// Delete parts of failed multipart, since we cannot currently continue them
-			u.LeavePartsOnError = false
 		})
 		// Print the progress bar. Second check is to filter out some junk from the output
 		if result != nil && result.VersionID != nil {
@@ -278,7 +276,10 @@ func uploadFiles(files, outFiles []string, targetDir string, config *helpers.Con
 		}
 
 		p.Shutdown()
-		fmt.Printf("file uploaded to %s\n", aws.ToString(&result.Location))
+		fmt.Printf("file uploaded to %s/%s/%s\n",
+			strings.TrimRight(config.HostBase, "/"),
+			config.AccessKey,
+			path.Join(targetDir, outFiles[k]))
 	}
 
 	return nil


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #658.


**Description**

`feature/s3/manager.Uploader` is deprecated. staticcheck (enabled in `.golangci.yml`) flags 5 `SA1019` on HEAD. Moves `upload/upload.go` and `list/list_test.go` onto `feature/s3/transfermanager`.

- `manager.NewUploader(s3Client)` becomes `transfermanager.New(s3Client, ...)`. `PartSize` moves from a per-call callback onto the client as `PartSizeBytes`. Still `int64`, still read from `helpers.Config.MultipartChunkSizeMb`.
- Dropped `LeavePartsOnError = false`. Old SDK defaulted to `false` anyway, and transfermanager aborts on error by default. No behavioural diff.
- `UploadObjectOutput.Location` is `*string` and only set by the multipart path (`mapFromCompleteMultipartUploadOutput`). Single-part returns `nil`, which broke the 4 upload test assertions. The success message now builds the path-style URL from `HostBase`, `AccessKey`, and the key, `url.PathEscape`'ing each segment so the output matches the old SDK's `EscapedPath()`.
- Adds a 60 MiB random fixture (`data_file_big`) to the integration workflow. With `PartSizeBytes = 50 MiB` the encrypted file is large enough to hit the multipart path. Existing 10 MiB fixture only covered single-part. Upload size is verified against the local file inline.


**How to test**

- `golangci-lint run` → 0 issues (was 5 × `SA1019`).
- `go test ./list/... ./upload/...` → 30 pass.
- `.github/workflows/integration.yml` runs both single-part (10 MiB) and multipart (60 MiB).