### PR TITLE
fix(encrypt): stabilize TestStream by dropping scheduling-dependent assertions

### DIFF
--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -615,6 +615,11 @@ func Stream(file *os.File, pubKeyList [][32]byte) (FileStream, error) {
 	return fs, nil
 }
 
+// FileStream is the output of Stream. The four hash fields are written
+// concurrently by a background goroutine as it copies the source file
+// through crypt4GHWriter. hash.Hash is not safe for concurrent use, so
+// callers must fully drain Reader (read until io.EOF) before calling
+// Sum on any of the hashes.
 type FileStream struct {
 	EncryptedMD5      hash.Hash
 	EncryptedSha256   hash.Hash

--- a/encrypt/encrypt_test.go
+++ b/encrypt/encrypt_test.go
@@ -262,8 +262,6 @@ func (s *EncryptTestSuite) TestStream() {
 
 	fs, err := Stream(file, [][32]byte{s.pubKeyData})
 	assert.NoError(s.T(), err, "failed to create encryption stream")
-	// make sure that no data is being read in order to save on memory
-	assert.Equal(s.T(), hex.EncodeToString(md5hash.Sum(nil)), hex.EncodeToString(fs.UnencryptedMD5.Sum(nil)))
 
 	enc, err := io.ReadAll(fs.Reader)
 	assert.NoError(s.T(), err, "failed to read from encryption stream")
@@ -276,8 +274,6 @@ func (s *EncryptTestSuite) TestStream() {
 	_ = fs.Reader.Close()
 }
 func (s *EncryptTestSuite) TestStreamLargeFile() {
-	md5hash := md5.New()
-
 	file, err := os.Open(s.largeFileToEncrypt.Name()) // #nosec G703
 	assert.NoError(s.T(), err, "opening file failed unexpectedly")
 	info, _ := file.Stat()
@@ -285,8 +281,6 @@ func (s *EncryptTestSuite) TestStreamLargeFile() {
 
 	fs, err := Stream(file, [][32]byte{s.pubKeyData})
 	assert.NoError(s.T(), err, "failed to create encryption stream")
-	// make sure that no data is being read in order to save on memory
-	assert.Equal(s.T(), hex.EncodeToString(md5hash.Sum(nil)), hex.EncodeToString(fs.UnencryptedMD5.Sum(nil)))
 
 	enc, err := io.ReadAll(fs.Reader)
 	assert.NoError(s.T(), err, "failed to read from encryption stream")


### PR DESCRIPTION
**Related issue(s) and PR(s)**
This PR closes #683.


**Description**
`TestEncryptTestSuite/TestStream` and `TestStreamLargeFile` were flaky on windows-latest. Both asserted `fs.UnencryptedMD5` equalled MD5("") right after `Stream()` returned. The problem: `Stream` launches a goroutine that updates the hash via `TeeReader` while `io.Copy` runs, so the assertion was really testing goroutine scheduling. On Windows the 7-byte copy sometimes finished before the assertion executed.

The fix drops the two pre-read assertions (plus the `md5.New()` in `TestStreamLargeFile` that went orphan). The `io.ReadAll` assertion further down still verifies the MD5 end-to-end once the stream is drained.

Tracing the root cause surfaced a related issue: `FileStream` exposes four mutable `hash.Hash` fields written by the background goroutine. The only production caller (`upload/upload.go`) reads them after `uploader.Upload` returns, which fully drains `fs.Reader`, and the ringbuffer's mutex gives happens-before. So nothing races in production today. The invariant wasn't documented though, so I added a doc comment on `FileStream` to keep future callers from repeating the mistake the test made.


**How to test**
- \`go test -count=20 -race ./encrypt/\` — 80/80 pass (was flaky on windows-latest)
- \`go test -race ./...\` — 456/456 pass
- \`golangci-lint run ./...\` — clean