### PR TITLE
add --bytes flag when listing files

### DIFF
--- a/.github/integration/tests/30_list.sh
+++ b/.github/integration/tests/30_list.sh
@@ -9,6 +9,14 @@ else
     exit 1
 fi
 
+size=$(wc -c < data_file.c4gh | awk '{print $1}')
+output=$(./sda-cli --config testing/s3cmd.conf list --bytes)
+if echo "$output" | grep -Eq "^${size}[[:space:]]+data_file\\.c4gh"; then
+    echo "Successfully listed files in bytes format"
+else
+    echo "Failed to list files in bytes format"
+    exit 1
+fi
 
 # Check listing files in a dataset
 output=$(./sda-cli --config testing/s3cmd-download.conf list --dataset https://doi.example/ty009.sfrrss/600.45asasga --url http://localhost:8080)

--- a/list/list.go
+++ b/list/list.go
@@ -11,7 +11,6 @@ import (
 	"github.com/NBISweden/sda-cli/downloadclient"
 	"github.com/NBISweden/sda-cli/helpers"
 	"github.com/dustin/go-humanize"
-	"github.com/inhies/go-bytesize"
 	"github.com/spf13/cobra"
 )
 
@@ -106,7 +105,7 @@ func list(configPath string, prefix string) error {
 
 	for i := range result {
 		file := *result[i].Key
-		fmt.Printf("%s \t %s \n", bytesize.New(float64((*result[i].Size))), file[strings.Index(file, "/")+1:])
+		fmt.Printf("%s \t %s \n", formatFileSizeOutput(*result[i].Size, bytesFormat), file[strings.Index(file, "/")+1:])
 	}
 
 	return nil

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -194,6 +194,22 @@ func (s *ListTestSuite) TestListFiles() {
 	assert.Contains(s.T(), string(listError), expectedHostBase)
 }
 
+func (s *ListTestSuite) TestListFilesBytesFormat() {
+	rescueStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	listCmd.Flag("bytes").Value.Set("true")
+	err := listCmd.Execute()
+	assert.NoError(s.T(), err)
+
+	_ = w.Close()
+	os.Stdout = rescueStdout
+	listOutput, _ := io.ReadAll(r)
+	_ = r.Close()
+	assert.Contains(s.T(), string(listOutput), fmt.Sprintf("%d \t testfile", len("test content")))
+}
+
 func (s *ListTestSuite) TestListDatasets() {
 	rescueStdout := os.Stdout
 	r, w, _ := os.Pipe()


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #709.


**Description**
Some users requested the option to be able to list files using the `--bytes` flag so they can compare the uploaded files and make sure the size is correct.

**How to test**
use the local setup, upload a file and list using the flag